### PR TITLE
Fix event timing

### DIFF
--- a/bin/c8.js
+++ b/bin/c8.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict'
 
+const {isAbsolute} = require('path')
 const argv = require('yargs').parse()
 const CRI = require('chrome-remote-interface')
 const spawn = require('../lib/spawn')
@@ -57,12 +58,8 @@ async function outputCoverage (Profiler) {
     /node-spawn-wrap/
   ]
   let {result} = await Profiler.takePreciseCoverage()
-  result = result.filter(coverage => {
-    for (var ignored, i = 0; (ignored = IGNORED_PATHS[i]) !== undefined; i++) {
-      if (ignored.test(coverage.url)) return false
-    }
-    if (!/^\//.test(coverage.url)) return false
-    else return true
+  result = result.filter(({url}) => {
+    return isAbsolute(url) && IGNORED_PATHS.every(ignored => !ignored.test(url))
   })
   console.log(JSON.stringify(result, null, 2))
 }


### PR DESCRIPTION
Fixes the symptoms documented at https://github.com/nodejs/node/issues/17336. This commit contains multiple parts that are hard to separate into separate commits/PRs, but I've documented the bits that I changed below:

- Use `process.execPath` instead of hardcoding `'node'`
- Make sure to call `done()` in the `foreground()` callback; doing this used to segfault for unknown reasons (presumably inside V8), but will no longer do so after the timing fixes in this PR
- Listen for Inspector events before enabling Profiler/Runtime/Debugger, since events will start flowing in as soon as those are enabled
- Attempt to enable Profiler/Runtime/Debugger before runIfWaitingForDebugger, but do not expect them to complete before runIfWaitingForDebugger finishes
- Wait for the initial pause brought about by `--inspect-brk` before doing anything further, like starting coverage tracking
- Ignore `executionContextDestroyed` signals for non-main contexts (e.g. VM contexts)
- Use Promises more extensively