### PR TITLE
feat: switch to stderr and default port

### DIFF
--- a/bin/c8.js
+++ b/bin/c8.js
@@ -2,20 +2,13 @@
 
 const argv = require('yargs').parse()
 const CRI = require('chrome-remote-interface')
-const getPort = require('get-port');
-const foreground = require('foreground-child')
-const waitTillPortOpen = require('wait-till-port-open')
+const spawn = require('../lib/spawn')
 
-getPort().then(async port => {
-  foreground(
-    ['node', `--inspect-brk=${port}`].concat(process.argv.slice(2)),
-    (done) => {
-      console.info('actually got here')
-    }
-  )
+;(async () => {
   try {
-    await waitTillPortOpen(port)
-    const client = await CRI({port: port})
+    info = await spawn(process.execPath,
+                       [`--inspect-brk=0`].concat(process.argv.slice(2)))                      
+    const client = await CRI({port: info.port})
 
     const {Debugger, Runtime, Profiler} = client
     await Runtime.runIfWaitingForDebugger()
@@ -38,7 +31,7 @@ getPort().then(async port => {
     console.error(err)
     process.exit(1)
   }
-})
+})()
 
 async function outputCoverage (Profiler) {
   const IGNORED_PATHS = [

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -1,0 +1,33 @@
+const {spawn} = require('child_process')
+
+const debuggerRe = /Debugger listening on ws:\/\/[^:]*:([^/]*)/
+
+module.exports = function (execPath, args=[]) {
+  const info = {
+    port: -1
+  }
+  return new Promise((resolve, reject) => {
+    const proc = spawn(execPath, args, {
+      stdio: [process.stdin, process.stdout, 'pipe'],
+      env: process.env,
+      cwd: process.cwd()
+    });
+
+    proc.stderr.on('data', (outBuffer) => {
+      const outString = outBuffer.toString('utf8')
+      const match = outString.match(debuggerRe)
+      if (match && !info.url) {
+        info.port = Number(match[1])
+        return resolve(info)
+      } else {
+        console.error(outString)
+      }
+    })
+    
+    proc.on('close', (code) => {
+      if (info.port === -1) {
+        return reject(Error('could not connect to inspector'))
+      }
+    })
+  })
+}

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
   "license": "ISC",
   "dependencies": {
     "chrome-remote-interface": "^0.25.2",
-    "foreground-child": "^1.5.6",
-    "get-port": "^3.2.0",
-    "wait-till-port-open": "^1.0.0",
     "yargs": "^10.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
allow inspector to pick a default port and, rather than polling for port, wait until port # is output to `stderr` 

I think if we were to add a standardized prefix to debugger output in Node.js, we could easily strip any messages generated by the debugger, while still kicking along other messages to `stderr` (refs: https://github.com/nodejs/node/issues/17337).

---

@TimothyGu, I assume that this message isn't output until the port is taking connections?

reviewer: @TimothyGu