### PR TITLE
fix: filter out results without `file` protocol

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -59,6 +59,12 @@ const exclude = Exclude({
 
 function filterResult (result) {
   result = result.filter(({url}) => {
+    if (!url.startsWith('file://')) {
+      // Sometimes a file produce an extra result without the `file://`
+      // protocol (simply its absolute path). This extra result has a different
+      // structure that breaks report merging, so we filter it out. See #14
+      return false
+    }
     url = url.replace('file://', '')
     return isAbsolute(url) &&
       exclude.shouldInstrument(url) &&


### PR DESCRIPTION
This commit ensures that the URL of the results starts with `file://`. Some files produce an extra result without the `file` protocol, this result interferes then with report merging.

See bcoe/c8#14