### PR TITLE
feat: add clean command

### DIFF
--- a/bin/c8.js
+++ b/bin/c8.js
@@ -18,8 +18,10 @@ if (argv._[0] === 'report') {
   argv = yargs.parse(process.argv) // support flag arguments after "report".
   outputReport()
 } else {
-  rimraf.sync(argv.tempDirectory)
-  mkdirp.sync(argv.tempDirectory)
+  if (argv.clean) {
+    rimraf.sync(argv.tempDirectory)
+    mkdirp.sync(argv.tempDirectory)
+  }
   process.env.NODE_V8_COVERAGE = argv.tempDirectory
 
   foreground(hideInstrumenterArgs(argv), () => {

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -24,10 +24,6 @@ yargs()
     default: [],
     describe: 'a list of specific files that should be covered (glob patterns are supported)'
   })
-  .option('coverage-directory', {
-    default: './coverage',
-    describe: 'directory to output coverage JSON and reports'
-  })
   .option('temp-directory', {
     default: './coverage/tmp',
     describe: 'directory V8 coverage data is written to and read from'
@@ -40,6 +36,11 @@ yargs()
     default: true,
     type: 'boolean',
     describe: 'omit any paths that are not absolute, e.g., internal/net.js'
+  })
+  .option('clean', {
+    default: true,
+    type: 'boolean',
+    describe: 'should temp files be deleted before script execution'
   })
   .command('report', 'read V8 coverage data from temp and output report')
   .pkgConf('c8')

--- a/test/integration.js
+++ b/test/integration.js
@@ -11,6 +11,7 @@ describe('c8', () => {
     const { output } = spawnSync(nodePath, [
       c8Path,
       '--exclude="test/*.js"',
+      '--clean=false',
       nodePath,
       require.resolve('./fixtures/normal')
     ])
@@ -28,17 +29,26 @@ All files  |    91.18 |    88.89 |        0 |    91.18 |                   |
     const { output } = spawnSync(nodePath, [
       c8Path,
       '--exclude="test/*.js"',
+      '--clean=false',
       nodePath,
       require.resolve('./fixtures/multiple-spawn')
     ])
     output.toString('utf8').should.include(`
--------------------|----------|----------|----------|----------|-------------------|
-File               |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------|----------|----------|----------|----------|-------------------|
-All files          |      100 |    77.78 |      100 |      100 |                   |
- multiple-spawn.js |      100 |      100 |      100 |      100 |                   |
- subprocess.js     |      100 |    71.43 |      100 |      100 |              9,13 |
--------------------|----------|----------|----------|----------|-------------------|`)
+--------------------|----------|----------|----------|----------|-------------------|
+File                |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+--------------------|----------|----------|----------|----------|-------------------|
+All files           |    94.12 |    70.59 |        0 |    94.12 |                   |
+ bin                |    83.72 |    57.14 |      100 |    83.72 |                   |
+  c8.js             |    83.72 |    57.14 |      100 |    83.72 |... 22,40,41,42,43 |
+ lib                |    96.41 |    65.38 |      100 |    96.41 |                   |
+  parse-args.js     |    97.47 |    44.44 |      100 |    97.47 |             55,56 |
+  report.js         |    95.45 |    76.47 |      100 |    95.45 |       51,52,53,54 |
+ test/fixtures      |    95.16 |    83.33 |        0 |    95.16 |                   |
+  async.js          |      100 |      100 |      100 |      100 |                   |
+  multiple-spawn.js |      100 |      100 |      100 |      100 |                   |
+  normal.js         |    85.71 |       75 |        0 |    85.71 |          14,15,16 |
+  subprocess.js     |      100 |    71.43 |      100 |      100 |              9,13 |
+--------------------|----------|----------|----------|----------|-------------------|`)
   })
 
   it('omit-relative can be set to false', () => {
@@ -46,6 +56,7 @@ All files          |      100 |    77.78 |      100 |      100 |                
       c8Path,
       '--exclude="test/*.js"',
       '--omit-relative=false',
+      '--clean=false',
       nodePath,
       require.resolve('./fixtures/multiple-spawn')
     ])


### PR DESCRIPTION
Adds clean command, which allows the deletion of the temporary directory to be skipped between runs of c8.

This is useful for our own test coverage, each run of c8 was stepping on the other's toes.