### PR TITLE
fix: Windows file:\/\// -> file:[\/]+

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -113,7 +113,7 @@ class Report {
     const result = []
     for (const v8ScriptCov of v8ProcessCov.result) {
       // TODO: implement real fix from https://github.com/nodejs/node/issues/23783
-      v8ScriptCov.url = v8ScriptCov.url.replace(/^file:\/\//, '')
+      v8ScriptCov.url = v8ScriptCov.url.replace(/^file:[\/]+/, '')
       if (this.exclude.shouldInstrument(v8ScriptCov.url) &&
         (!this.omitRelative || isAbsolute(v8ScriptCov.url))) {
         result.push(v8ScriptCov)


### PR DESCRIPTION
On Windows (edit: [it seems](https://superuser.com/questions/352133/why-do-file-urls-start-with-3-slashes) this can be a case on other OSes too) there seems to be `file:///` i.e. 3 forward slashes, whereas here it was only accounting for 2, leaving in an extra `/`

Fixes #41

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `npm test`, tests passing

   Weren't passing for me before this fix either.
 
~~`npm run test:snap` (to update the snapshot)~~ shouldn't be needed
~~tests and/or benchmarks are included~~
~~ documentation is changed or added~~
