### PR TITLE
Proposition for fixing Issue #64

### DIFF
--- a/lib/commands/check-coverage.js
+++ b/lib/commands/check-coverage.js
@@ -15,6 +15,7 @@ exports.handler = function (argv) {
     include: argv.include,
     exclude: argv.exclude,
     reporter: Array.isArray(argv.reporter) ? argv.reporter : [argv.reporter],
+    reportsDirectory: argv['reports-dir'],
     tempDirectory: argv.tempDirectory,
     watermarks: argv.watermarks,
     resolve: argv.resolve,

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -14,6 +14,7 @@ exports.outputReport = function (argv) {
     include: argv.include,
     exclude: argv.exclude,
     reporter: Array.isArray(argv.reporter) ? argv.reporter : [argv.reporter],
+    reportsDirectory: argv['reports-dir'],
     tempDirectory: argv.tempDirectory,
     watermarks: argv.watermarks,
     resolve: argv.resolve,

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -15,6 +15,11 @@ function buildYargs (withCommands = false) {
       describe: 'coverage reporter(s) to use',
       default: 'text'
     })
+    .option('reports-dir', {
+      alias: 'o',
+      describe: 'reports directory, where reports is written to',
+      default: './coverage'
+    })
     .option('exclude', {
       alias: 'x',
       default: Exclude.defaultExclude,

--- a/lib/report.js
+++ b/lib/report.js
@@ -14,16 +14,18 @@ class Report {
     exclude,
     include,
     reporter,
+    reportsDirectory,
     tempDirectory,
     watermarks,
-    resolve,
     omitRelative,
-    wrapperLength
+    wrapperLength,
+    resolve: resolvePaths
   }) {
     this.reporter = reporter
+    this.reportsDirectory = reportsDirectory
     this.tempDirectory = tempDirectory
     this.watermarks = watermarks
-    this.resolve = resolve
+    this.resolve = resolvePaths
     this.exclude = Exclude({
       exclude: exclude,
       include: include
@@ -34,7 +36,7 @@ class Report {
   run () {
     const map = this.getCoverageMapFromAllCoverageFiles()
     var context = libReport.createContext({
-      dir: './coverage',
+      dir: this.reportsDirectory,
       watermarks: this.watermarks
     })
 

--- a/test/integration.js.snap
+++ b/test/integration.js.snap
@@ -12,27 +12,27 @@ hey
 --------------------|----------|----------|----------|----------|-------------------|
 File                |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
 --------------------|----------|----------|----------|----------|-------------------|
-All files           |    95.46 |    76.83 |    89.66 |    95.46 |                   |
+All files           |    95.55 |    76.83 |    89.66 |    95.55 |                   |
  bin                |    85.71 |    83.33 |      100 |    85.71 |                   |
   c8.js             |    85.71 |    83.33 |      100 |    85.71 |    25,32,33,34,35 |
- lib                |     97.1 |       65 |      100 |     97.1 |                   |
-  parse-args.js     |    98.41 |    53.85 |      100 |    98.41 |           102,103 |
-  report.js         |       96 |    70.37 |      100 |       96 |... 08,134,135,136 |
- lib/commands       |    97.67 |    84.21 |     87.5 |    97.67 |                   |
+ lib                |    97.17 |       65 |      100 |    97.17 |                   |
+  parse-args.js     |    98.47 |    53.85 |      100 |    98.47 |           107,108 |
+  report.js         |    96.05 |    70.37 |      100 |    96.05 |... 10,136,137,138 |
+ lib/commands       |    97.73 |    84.21 |     87.5 |    97.73 |                   |
   check-coverage.js |      100 |    92.86 |      100 |      100 |                17 |
-  report.js         |    92.31 |       60 |       50 |    92.31 |              9,10 |
+  report.js         |    92.59 |       60 |       50 |    92.59 |              9,10 |
  test/fixtures      |    90.91 |    94.12 |       75 |    90.91 |                   |
   async.js          |      100 |      100 |      100 |      100 |                   |
   multiple-spawn.js |      100 |      100 |      100 |      100 |                   |
   normal.js         |       76 |       75 |    33.33 |       76 | 14,15,16,18,19,20 |
   subprocess.js     |      100 |      100 |      100 |      100 |                   |
 --------------------|----------|----------|----------|----------|-------------------|
-,ERROR: Coverage for lines (95.46%) does not meet global threshold (101%)
+,ERROR: Coverage for lines (95.55%) does not meet global threshold (101%)
 "
 `;
 
 exports[`c8 check-coverage allows threshold to be applied on per-file basis 1`] = `
-",,ERROR: Coverage for lines (78.33%) does not meet threshold (80%) for lib/commands/check-coverage.js
+",,ERROR: Coverage for lines (78.69%) does not meet threshold (80%) for lib/commands/check-coverage.js
 ERROR: Coverage for lines (76%) does not meet threshold (80%) for test/fixtures/normal.js
 "
 `;
@@ -40,7 +40,7 @@ ERROR: Coverage for lines (76%) does not meet threshold (80%) for test/fixtures/
 exports[`c8 check-coverage exits with 0 if coverage within threshold 1`] = `",,"`;
 
 exports[`c8 check-coverage exits with 1 if coverage is below threshold 1`] = `
-",,ERROR: Coverage for lines (95.03%) does not meet global threshold (101%)
+",,ERROR: Coverage for lines (95.13%) does not meet global threshold (101%)
 "
 `;
 
@@ -52,15 +52,15 @@ second
 --------------------|----------|----------|----------|----------|-------------------|
 File                |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
 --------------------|----------|----------|----------|----------|-------------------|
-All files           |    84.67 |    68.18 |    74.07 |    84.67 |                   |
+All files           |    84.75 |    68.18 |    74.07 |    84.75 |                   |
  bin                |    85.71 |    66.67 |      100 |    85.71 |                   |
   c8.js             |    85.71 |    66.67 |      100 |    85.71 |    25,32,33,34,35 |
- lib                |    95.65 |    55.56 |      100 |    95.65 |                   |
-  parse-args.js     |    96.83 |    41.67 |      100 |    96.83 |     88,89,102,103 |
-  report.js         |    94.67 |     62.5 |      100 |    94.67 |... 08,134,135,136 |
- lib/commands       |    44.19 |    71.43 |    16.67 |    44.19 |                   |
-  check-coverage.js |    23.33 |      100 |        0 |    23.33 |... 55,56,57,58,59 |
-  report.js         |    92.31 |       60 |       50 |    92.31 |              9,10 |
+ lib                |    95.76 |    55.56 |      100 |    95.76 |                   |
+  parse-args.js     |    96.95 |    41.67 |      100 |    96.95 |     93,94,107,108 |
+  report.js         |    94.74 |     62.5 |      100 |    94.74 |... 10,136,137,138 |
+ lib/commands       |    44.32 |    71.43 |    16.67 |    44.32 |                   |
+  check-coverage.js |    22.95 |      100 |        0 |    22.95 |... 56,57,58,59,60 |
+  report.js         |    92.59 |       60 |       50 |    92.59 |              9,10 |
  test/fixtures      |    90.91 |    94.12 |       75 |    90.91 |                   |
   async.js          |      100 |      100 |      100 |      100 |                   |
   multiple-spawn.js |      100 |      100 |      100 |      100 |                   |
@@ -74,15 +74,15 @@ exports[`c8 report generates report from existing temporary files 1`] = `
 ",--------------------|----------|----------|----------|----------|-------------------|
 File                |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
 --------------------|----------|----------|----------|----------|-------------------|
-All files           |    95.46 |    79.76 |    89.66 |    95.46 |                   |
+All files           |    95.55 |    79.76 |    89.66 |    95.55 |                   |
  bin                |    85.71 |    85.71 |      100 |    85.71 |                   |
   c8.js             |    85.71 |    85.71 |      100 |    85.71 |    25,32,33,34,35 |
- lib                |     97.1 |    69.05 |      100 |     97.1 |                   |
-  parse-args.js     |    98.41 |    53.85 |      100 |    98.41 |           102,103 |
-  report.js         |       96 |    75.86 |      100 |       96 |... 08,134,135,136 |
- lib/commands       |    97.67 |    88.89 |     87.5 |    97.67 |                   |
+ lib                |    97.17 |    69.05 |      100 |    97.17 |                   |
+  parse-args.js     |    98.47 |    53.85 |      100 |    98.47 |           107,108 |
+  report.js         |    96.05 |    75.86 |      100 |    96.05 |... 10,136,137,138 |
+ lib/commands       |    97.73 |    88.89 |     87.5 |    97.73 |                   |
   check-coverage.js |      100 |    92.31 |      100 |      100 |                17 |
-  report.js         |    92.31 |       80 |       50 |    92.31 |              9,10 |
+  report.js         |    92.59 |       80 |       50 |    92.59 |              9,10 |
  test/fixtures      |    90.91 |    94.12 |       75 |    90.91 |                   |
   async.js          |      100 |      100 |      100 |      100 |                   |
   multiple-spawn.js |      100 |      100 |      100 |      100 |                   |
@@ -96,12 +96,12 @@ exports[`c8 report supports --check-coverage, when generating reports 1`] = `
 ",--------------------|----------|----------|----------|----------|-------------------|
 File                |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
 --------------------|----------|----------|----------|----------|-------------------|
-All files           |     95.9 |    79.76 |     93.1 |     95.9 |                   |
+All files           |    95.97 |    79.76 |     93.1 |    95.97 |                   |
  bin                |    85.71 |    83.33 |      100 |    85.71 |                   |
   c8.js             |    85.71 |    83.33 |      100 |    85.71 |    25,32,33,34,35 |
- lib                |     97.1 |    69.05 |      100 |     97.1 |                   |
-  parse-args.js     |    98.41 |    53.85 |      100 |    98.41 |           102,103 |
-  report.js         |       96 |    75.86 |      100 |       96 |... 08,134,135,136 |
+ lib                |    97.17 |    69.05 |      100 |    97.17 |                   |
+  parse-args.js     |    98.47 |    53.85 |      100 |    98.47 |           107,108 |
+  report.js         |    96.05 |    75.86 |      100 |    96.05 |... 10,136,137,138 |
  lib/commands       |      100 |    89.47 |      100 |      100 |                   |
   check-coverage.js |      100 |    92.31 |      100 |      100 |                17 |
   report.js         |      100 |    83.33 |      100 |      100 |                16 |
@@ -111,7 +111,7 @@ All files           |     95.9 |    79.76 |     93.1 |     95.9 |               
   normal.js         |       76 |       75 |    33.33 |       76 | 14,15,16,18,19,20 |
   subprocess.js     |      100 |      100 |      100 |      100 |                   |
 --------------------|----------|----------|----------|----------|-------------------|
-,ERROR: Coverage for lines (95.9%) does not meet global threshold (101%)
+,ERROR: Coverage for lines (95.97%) does not meet global threshold (101%)
 "
 `;
 


### PR DESCRIPTION
Add new option `--reports-dir` for customization of the reports output. 

Tests notice: as this new option is bypassed directly to reporter framework, I think that testing of different outputting should be already tested there. Maybe you have other opinion?

Thank u for the attention