### PR TITLE
feat: print warning and abort for non-compatible Node.js versions

### DIFF
--- a/bin/c8.js
+++ b/bin/c8.js
@@ -1,35 +1,11 @@
 #!/usr/bin/env node
 'use strict'
 
-const fs = require('fs')
-const foreground = require('foreground-child')
-const { outputReport } = require('../lib/commands/report')
-const { promisify } = require('util')
-const rimraf = require('rimraf')
-const {
-  buildYargs,
-  hideInstrumenteeArgs,
-  hideInstrumenterArgs
-} = require('../lib/parse-args')
+const semver = require('semver')
 
-const instrumenterArgs = hideInstrumenteeArgs()
-let argv = buildYargs().parse(instrumenterArgs)
-
-;(async function run () {
-  if ([
-    'check-coverage', 'report'
-  ].indexOf(argv._[0]) !== -1) {
-    argv = buildYargs(true).parse(process.argv.slice(2))
-  } else {
-    if (argv.clean) {
-      await promisify(rimraf)(argv.tempDirectory)
-      await promisify(fs.mkdir)(argv.tempDirectory, { recursive: true })
-    }
-
-    process.env.NODE_V8_COVERAGE = argv.tempDirectory
-    foreground(hideInstrumenterArgs(argv), async (done) => {
-      await outputReport(argv)
-      done()
-    })
-  }
-})()
+if (semver.lt(process.version, '10.0.0')) {
+  /* c8 ignore next */
+  console.warn(`c8 requires Node v10.0.0 or greater, found ${process.version}`)
+} else {
+  require('./run')
+}

--- a/bin/c8.js
+++ b/bin/c8.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict'
 
-const minNode = `10.12.0`
 const semver = require('semver')
+const minNode = semver.minVersion(require('../package.json').engines.node)
 
 /* c8 ignore next 3 */
 if (semver.lt(process.version, minNode)) {

--- a/bin/c8.js
+++ b/bin/c8.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 'use strict'
 
+const minNode = `10.12.0`
 const semver = require('semver')
 
 /* c8 ignore next 3 */
-if (semver.lt(process.version, '10.12.0')) {
-  console.warn(`c8 requires Node v10.12.0 or greater, found ${process.version}`)
+if (semver.lt(process.version, minNode)) {
+  console.warn(`c8 requires Node v${minNode} or greater, found ${process.version}`)
 } else {
   require('./run')
 }

--- a/bin/c8.js
+++ b/bin/c8.js
@@ -3,9 +3,9 @@
 
 const semver = require('semver')
 
-if (semver.lt(process.version, '10.0.0')) {
-  /* c8 ignore next */
-  console.warn(`c8 requires Node v10.0.0 or greater, found ${process.version}`)
+/* c8 ignore next 3 */
+if (semver.lt(process.version, '10.12.0')) {
+  console.warn(`c8 requires Node v10.12.0 or greater, found ${process.version}`)
 } else {
   require('./run')
 }

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+'use strict'
+
+const fs = require('fs')
+const foreground = require('foreground-child')
+const { outputReport } = require('../lib/commands/report')
+const { promisify } = require('util')
+const rimraf = require('rimraf')
+const {
+  buildYargs,
+  hideInstrumenteeArgs,
+  hideInstrumenterArgs
+} = require('../lib/parse-args')
+
+const instrumenterArgs = hideInstrumenteeArgs()
+let argv = buildYargs().parse(instrumenterArgs)
+
+;(async function run () {
+  if ([
+    'check-coverage', 'report'
+  ].indexOf(argv._[0]) !== -1) {
+    argv = buildYargs(true).parse(process.argv.slice(2))
+  } else {
+    if (argv.clean) {
+      await promisify(rimraf)(argv.tempDirectory)
+      await promisify(fs.mkdir)(argv.tempDirectory, { recursive: true })
+    }
+
+    process.env.NODE_V8_COVERAGE = argv.tempDirectory
+    foreground(hideInstrumenterArgs(argv), async (done) => {
+      await outputReport(argv)
+      done()
+    })
+  }
+})()
+

--- a/bin/run.js
+++ b/bin/run.js
@@ -33,4 +33,3 @@ let argv = buildYargs().parse(instrumenterArgs)
     })
   }
 })()
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -3744,9 +3744,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-3.1.1.tgz",
-      "integrity": "sha512-eHpQJtskRnviG5/OHIUmj9vrUqPDO5WY0MGAuILKSgL6f8x4AVHxpFxCmXFshHw5zhOOznP6VRtxPr+6lNoK+w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-3.1.2.tgz",
+      "integrity": "sha512-2ae2rql4/nCb+E9sRoXmoiDyJAeFhPZ6t5ZQpb/Kls/vff3dD0wjWEUadkunLT0AkflMxQAB1deiiysL7DeN/w==",
       "requires": {
         "convert-source-map": "^1.6.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -624,6 +624,14 @@
         "semver": "^5.5.0",
         "split": "^1.0.0",
         "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "conventional-commits-filter": {
@@ -713,6 +721,13 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "currently-unhandled": {
@@ -1035,6 +1050,14 @@
         "strip-json-comments": "^2.0.1",
         "table": "^4.0.3",
         "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "eslint-config-standard": {
@@ -1170,6 +1193,14 @@
         "minimatch": "^3.0.4",
         "resolve": "^1.8.1",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-promise": {
@@ -1721,6 +1752,14 @@
       "requires": {
         "meow": "^4.0.0",
         "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "gitconfiglocal": {
@@ -2618,6 +2657,13 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "npm-run-path": {
@@ -3213,9 +3259,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -3427,6 +3473,12 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "istanbul-reports": "^2.0.0",
     "rimraf": "^2.6.2",
     "test-exclude": "^5.0.0",
-    "v8-to-istanbul": "^3.1.1",
+    "v8-to-istanbul": "^3.1.2",
     "yargs": "^13.1.0",
     "yargs-parser": "^10.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "istanbul-lib-report": "^2.0.1",
     "istanbul-reports": "^2.0.0",
     "rimraf": "^2.6.2",
+    "semver": "^6.0.0",
     "test-exclude": "^5.0.0",
     "v8-to-istanbul": "^3.1.2",
     "yargs": "^13.1.0",


### PR DESCRIPTION
rather than failing with a cryptic parsing error, or outputting no coverage, print a warning on older versions of Node.js.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
