### PR TITLE
fix: remove the unmaintained mkdirp dependency

### DIFF
--- a/bin/c8.js
+++ b/bin/c8.js
@@ -3,7 +3,7 @@
 
 const foreground = require('foreground-child')
 const { outputReport } = require('../lib/commands/report')
-const mkdirp = require('mkdirp')
+const { promises } = require('fs')
 const { promisify } = require('util')
 const rimraf = require('rimraf')
 const {
@@ -25,7 +25,9 @@ async function run () {
       await promisify(rimraf)(argv.tempDirectory)
     }
     // allow c8 to run on Node 8 (coverage just won't work).
-    await promisify(mkdirp)(argv.tempDirectory)
+    if (promises) {
+      await promises.mkdir(argv.tempDirectory, { recursive: true })
+    }
 
     process.env.NODE_V8_COVERAGE = argv.tempDirectory
     foreground(hideInstrumenterArgs(argv), async (done) => {

--- a/bin/c8.js
+++ b/bin/c8.js
@@ -21,7 +21,8 @@ async function run () {
   ].indexOf(argv._[0]) !== -1) {
     argv = buildYargs(true).parse(process.argv.slice(2))
   } else {
-    // allow c8 to run on Node 8 (coverage just won't work).
+    // fs.promises was not added until Node.js v10.0.0, if it doesn't
+    // exist, assume we're Node.js v8.x and skip coverage.
     if (!promises) {
       foreground(hideInstrumenterArgs(argv))
       return

--- a/bin/c8.js
+++ b/bin/c8.js
@@ -21,14 +21,17 @@ async function run () {
   ].indexOf(argv._[0]) !== -1) {
     argv = buildYargs(true).parse(process.argv.slice(2))
   } else {
+    // allow c8 to run on Node 8 (coverage just won't work).
+    if (!promises) {
+      foreground(hideInstrumenterArgs(argv))
+      return
+    }
+
     if (argv.clean) {
       await promisify(rimraf)(argv.tempDirectory)
     }
-    // allow c8 to run on Node 8 (coverage just won't work).
-    if (promises) {
-      await promises.mkdir(argv.tempDirectory, { recursive: true })
-    }
 
+    await promises.mkdir(argv.tempDirectory, { recursive: true })
     process.env.NODE_V8_COVERAGE = argv.tempDirectory
     foreground(hideInstrumenterArgs(argv), async (done) => {
       try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2505,6 +2505,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "istanbul-lib-coverage": "^2.0.1",
     "istanbul-lib-report": "^2.0.1",
     "istanbul-reports": "^2.0.0",
-    "mkdirp": "^0.5.1",
     "rimraf": "^2.6.2",
     "test-exclude": "^5.0.0",
     "v8-to-istanbul": "^3.1.1",

--- a/test/fixtures/disable-fs-promises.js
+++ b/test/fixtures/disable-fs-promises.js
@@ -1,0 +1,4 @@
+const fs = require('fs');
+
+Object.defineProperty(fs, 'promises', {value: undefined});
+require('../../bin/c8.js');

--- a/test/legacy-node.js
+++ b/test/legacy-node.js
@@ -1,20 +1,22 @@
 /* global describe, it */
 
 const { execFile } = require('child_process')
-const { mkdir } = require('fs').promises
+const { existsSync } = require('fs')
 const { join } = require('path')
 const { promisify } = require('util')
 const c8Path = require.resolve('./fixtures/disable-fs-promises')
-const nodePath = process.execPath
 
 describe('c8 on Node.js < 10', () => {
-  it('doesn\'t crash', async () => {
-    await mkdir(join(__dirname, '..', 'tmp', 'legacy-nodejs'))
-    await promisify(execFile)(nodePath, [
+  it('skip coverage', async () => {
+    const tmp = join(__dirname, '..', 'tmp', 'legacy-nodejs')
+
+    await promisify(execFile)(process.execPath, [
       c8Path,
-      '--temp-directory=tmp/legacy-nodejs',
-      'node',
+      `--temp-directory=${__filename}`,
+      process.execPath,
       '--version'
     ])
+
+    existsSync(tmp).should.equal(false)
   })
 })

--- a/test/legacy-node.js
+++ b/test/legacy-node.js
@@ -1,0 +1,20 @@
+/* global describe, it */
+
+const { execFile } = require('child_process')
+const { mkdir } = require('fs').promises
+const { join } = require('path')
+const { promisify } = require('util')
+const c8Path = require.resolve('./fixtures/disable-fs-promises')
+const nodePath = process.execPath
+
+describe('c8 on Node.js < 10', () => {
+  it('doesn\'t crash', async () => {
+    await mkdir(join(__dirname, '..', 'tmp', 'legacy-nodejs'))
+    await promisify(execFile)(nodePath, [
+      c8Path,
+      '--temp-directory=tmp/legacy-nodejs',
+      'node',
+      '--version'
+    ])
+  })
+})


### PR DESCRIPTION
https://github.com/bcoe/c8/commit/206b83f156ff93d1a7b211d61bd4fd8e9a4cd95f introduced the `mkdirp` dependency to `c8`, but I'm very opposed to use such a no longer maintained package.

For feature detection, we can check the existence of [`fs.promises`](https://nodejs.org/dist/latest-v12.x/docs/api/fs.html#fs_fs_promises_api) which is only available in Node.js >= 10.0.0.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
