### PR TITLE
fix: exit with code 1 when report output fails

### DIFF
--- a/bin/c8.js
+++ b/bin/c8.js
@@ -29,7 +29,12 @@ async function run () {
 
     process.env.NODE_V8_COVERAGE = argv.tempDirectory
     foreground(hideInstrumenterArgs(argv), async (done) => {
-      await outputReport(argv)
+      try {
+        await outputReport(argv)
+      } catch (err) {
+        console.error(err.stack)
+        process.exitCode = 1
+      }
       done()
     })
   }

--- a/test/integration.js
+++ b/test/integration.js
@@ -53,6 +53,18 @@ describe('c8', () => {
     )
   })
 
+  it('exits with 1 when report output fails', () => {
+    const { status, stderr } = spawnSync(nodePath, [
+      c8Path,
+      '--clean=false',
+      '--reporter=unknown',
+      nodePath,
+      '--version'
+    ])
+    status.should.equal(1)
+    stderr.toString().should.match(/Cannot find module 'unknown'/u)
+  })
+
   describe('check-coverage', () => {
     before(() => {
       spawnSync(nodePath, [


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

Currently, when `c8` fails to create coverage reports because of, for example, unknown report type `--reporter=unknown`, it causes the following two problems:

__1__. The error is displayed as an `UnhandledPromiseRejectionWarning` to end users.

```console
$ c8 --reporter=unknown echo ""

(node:26891) UnhandledPromiseRejectionWarning: Error: Cannot find module 'unknown'
Require stack:
- /Users/shinnn/c8/node_modules/istanbul-reports/index.js
- /Users/shinnn/c8/lib/report.js
- /Users/shinnn/c8/lib/commands/check-coverage.js
- /Users/shinnn/c8/lib/commands/report.js
- /Users/shinnn/c8/bin/c8.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:610:15)
    at Function.Module._load (internal/modules/cjs/loader.js:526:27)
    at Module.require (internal/modules/cjs/loader.js:666:19)
    at require (internal/modules/cjs/helpers.js:16:16)
    at Object.create (/Users/shinnn/c8/node_modules/istanbul-reports/index.js:14:20)
    at /Users/shinnn/c8/lib/report.js:47:26
    at Array.forEach (<anonymous>)
    at Report.run (/Users/shinnn/c8/lib/report.js:46:19)
    at processTicksAndRejections (internal/process/task_queues.js:89:5)
    at async exports.outputReport (/Users/shinnn/c8/lib/commands/report.js:24:3)
(node:26891) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:26891) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

__2__. `c8` exits with code `0`.

```console
$ echo $?
0
```

This patch solves those problems by explicitly catching report creation errors and exiting with `1`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] tests and/or benchmarks are included
