### PR TITLE
feat: load .nycrc/.nycrc.json to simplify migration

### DIFF
--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -4,7 +4,7 @@ const { readFileSync } = require('fs')
 const Yargs = require('yargs/yargs')
 const parser = require('yargs-parser')
 
-const configPath = findUp.sync(['.c8rc', '.c8rc.json'])
+const configPath = findUp.sync(['.c8rc', '.c8rc.json', '.nycrc', `.nycrc.json`])
 const config = configPath ? JSON.parse(readFileSync(configPath)) : {}
 
 function buildYargs (withCommands = false) {


### PR DESCRIPTION
To simplify migrating from `nyc` to `c8`, support loading `.nycrc`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
