### PR TITLE
feat!: default temp directory to report directory

### DIFF
--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -61,7 +61,6 @@ function buildYargs (withCommands = false) {
       type: 'boolean'
     })
     .option('temp-directory', {
-      default: './coverage/tmp',
       describe: 'directory V8 coverage data is written to and read from'
     })
     .option('resolve', {
@@ -85,6 +84,12 @@ function buildYargs (withCommands = false) {
     .pkgConf('c8')
     .config(config)
     .demandCommand(1)
+    .check((argv) => {
+      if (!argv.tempDirectory) {
+        argv.tempDirectory = argv.reportsDir
+      }
+      return true
+    })
     .epilog('visit https://git.io/vHysA for list of available reporters')
 
   const checkCoverage = require('./commands/check-coverage')


### PR DESCRIPTION
BREAKING CHANGE: temp directory now defaults to setting for report directory
