### PR TITLE
fix: temporary files should be in tmp folder

### DIFF
--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -3,6 +3,7 @@ const findUp = require('find-up')
 const { readFileSync } = require('fs')
 const Yargs = require('yargs/yargs')
 const parser = require('yargs-parser')
+const { resolve } = require('path')
 
 const configPath = findUp.sync(['.c8rc', '.c8rc.json', '.nycrc', `.nycrc.json`])
 const config = configPath ? JSON.parse(readFileSync(configPath)) : {}
@@ -86,7 +87,7 @@ function buildYargs (withCommands = false) {
     .demandCommand(1)
     .check((argv) => {
       if (!argv.tempDirectory) {
-        argv.tempDirectory = argv.reportsDir
+        argv.tempDirectory = resolve(argv.reportsDir, 'tmp')
       }
       return true
     })


### PR DESCRIPTION
temporary files were being placed in top-level `coverage` folder.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
