### PR TITLE
fix: HTML report now has correct source positions for Node >10.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,11 @@
       "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8="
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -3999,10 +4004,11 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-3.1.3.tgz",
-      "integrity": "sha512-btJfK2L4PhLMSkD1yiYEAAaz7xEwAiCJsxJ+mg+zc2ghYWGHcg6V3bgKpQmdBr7EmmnckZE0zvminOVF1tXk2g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-3.2.2.tgz",
+      "integrity": "sha512-R3NhjMpoTSL34OnHgkdeiWgYsKb8+hKLmGRBc1j7adslGUN6FMQCSPRARCRFHAkjaT3urTBcq5hW05PksFpBCQ==",
       "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.1",
         "convert-source-map": "^1.6.0",
         "source-map": "^0.7.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4004,9 +4004,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-3.2.2.tgz",
-      "integrity": "sha512-R3NhjMpoTSL34OnHgkdeiWgYsKb8+hKLmGRBc1j7adslGUN6FMQCSPRARCRFHAkjaT3urTBcq5hW05PksFpBCQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-3.2.3.tgz",
+      "integrity": "sha512-B8d/oxMtc/x0TYXr9b+Ywu5KexA/on4QMQ9M1kTYnoGZzKdo8LLk9ySlWePdDOtr2G0/2Injgcp3sOR9gU+3vQ==",
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
         "convert-source-map": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "istanbul-reports": "^2.2.4",
     "rimraf": "^2.6.2",
     "test-exclude": "^5.0.0",
-    "v8-to-istanbul": "^3.1.3",
+    "v8-to-istanbul": "^3.2.2",
     "yargs": "^13.1.0",
     "yargs-parser": "^13.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "istanbul-reports": "^2.2.4",
     "rimraf": "^2.6.2",
     "test-exclude": "^5.0.0",
-    "v8-to-istanbul": "^3.2.2",
+    "v8-to-istanbul": "^3.2.3",
     "yargs": "^13.1.0",
     "yargs-parser": "^13.0.0"
   },


### PR DESCRIPTION
This pulls in a fix to v8-to-istanbul that addresses the bug reported by @oliversalzburg.

CC: @shinnn, I used your patch.