### PR TITLE
fix: All flag not propagated to check-coverage command

### DIFF
--- a/lib/commands/check-coverage.js
+++ b/lib/commands/check-coverage.js
@@ -20,7 +20,8 @@ exports.handler = function (argv) {
     watermarks: argv.watermarks,
     resolve: argv.resolve,
     omitRelative: argv.omitRelative,
-    wrapperLength: argv.wrapperLength
+    wrapperLength: argv.wrapperLength,
+    all: argv.all
   })
   exports.checkCoverages(argv, report)
 }

--- a/test/integration.js.snap
+++ b/test/integration.js.snap
@@ -65,6 +65,29 @@ All files     |   64.29 |    66.67 |      50 |   64.29 |
 ,"
 `;
 
+exports[`c8 --all should allow for --all to be used in conjunction with --check-coverage 1`] = `
+",zero
+positive
+negative
+--------------|---------|----------|---------|---------|-------------------
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+--------------|---------|----------|---------|---------|-------------------
+All files     |   64.29 |    66.67 |      50 |   64.29 |                   
+ vanilla      |   78.26 |       75 |     100 |   78.26 |                   
+  loaded.js   |   73.68 |    71.43 |     100 |   73.68 | 4,5,16-18         
+  main.js     |     100 |      100 |     100 |     100 |                   
+ vanilla/dir  |       0 |        0 |       0 |       0 |                   
+  unloaded.js |       0 |        0 |       0 |       0 | 1-5               
+--------------|---------|----------|---------|---------|-------------------
+,ERROR: Coverage for lines (64.29%) does not meet global threshold (100%)
+"
+`;
+
+exports[`c8 --all should allow for --all to be used with the check-coverage command (2 invocations) 1`] = `
+",,ERROR: Coverage for lines (64.29%) does not meet global threshold (90%)
+"
+`;
+
 exports[`c8 ESM Modules collects coverage for ESM modules 1`] = `
 ",bar foo
 ------------|---------|----------|---------|---------|-------------------


### PR DESCRIPTION
Fixes: https://github.com/bcoe/c8/issues/187

When implementing all I neglected to supply it when building
`Report` in the `check-coverage.js` command. This commit
rectifies that and adds two test cases for `check-coverage`
as a flag and command used in conjunction with `--all` to
prevent regression.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x ] `npm test`, tests passing
- [ x ] `npm run test:snap` (to update the snapshot)
- [ x ] tests and/or benchmarks are included
- [ ] documentation is changed or added
