### PR TITLE
fix: stop duplicating names on case-insensitive file systems

### DIFF
--- a/lib/path-set.js
+++ b/lib/path-set.js
@@ -1,0 +1,25 @@
+/**
+ * A unique set of paths. Case insensitive on win32
+ */
+class PathSet extends Set {
+  constructor () {
+    super()
+    this._win32 = process.platform === 'win32'
+  }
+
+  add (value) {
+    if (this._win32) {
+      value = value.toLowerCase()
+    }
+    super.add(value)
+  }
+
+  has (value) {
+    if (this._win32) {
+      value = value.toLowerCase()
+    }
+    return super.has(value)
+  }
+}
+
+module.exports = PathSet

--- a/lib/path-set.js
+++ b/lib/path-set.js
@@ -12,6 +12,7 @@ class PathSet extends Set {
       value = value.toLowerCase()
     }
     super.add(value)
+    return this
   }
 
   has (value) {

--- a/lib/report.js
+++ b/lib/report.js
@@ -3,6 +3,7 @@ const furi = require('furi')
 const libCoverage = require('istanbul-lib-coverage')
 const libReport = require('istanbul-lib-report')
 const reports = require('istanbul-reports')
+const PathSet = require('./path-set')
 const { readdirSync, readFileSync, statSync } = require('fs')
 const { isAbsolute, resolve, extname } = require('path')
 const getSourceMapFromFile = require('./source-map-from-file')
@@ -144,7 +145,7 @@ class Report {
   _getMergedProcessCov () {
     const { mergeProcessCovs } = require('@bcoe/v8-coverage')
     const v8ProcessCovs = []
-    const fileIndex = new Set() // Set<string>
+    const fileIndex = new PathSet() // PathSet<string>
     for (const v8ProcessCov of this._loadReports()) {
       if (this._isCoverageObject(v8ProcessCov)) {
         if (v8ProcessCov['source-map-cache']) {
@@ -217,7 +218,7 @@ class Report {
           'utf8'
         ))
       } catch (err) {
-        console.warn(`${err.stack}`)
+        console.warn(`Failed to parse tmp file: ${f} with: ${err.stack}`)
       }
     })
   }

--- a/test/fixtures/all/mock-v8-output/bad-casing.json
+++ b/test/fixtures/all/mock-v8-output/bad-casing.json
@@ -1,0 +1,74 @@
+{
+  "result": [
+    {
+      "scriptId": "51",
+      "url": "file:///TEST_CWD/test/fixtures/all/vanilla/MAIN.js",
+      "functions": [
+        {
+          "functionName": "",
+          "ranges": [
+            {
+              "startOffset": 0,
+              "endOffset": 111,
+              "count": 1
+            }
+          ],
+          "isBlockCoverage": true
+        }
+      ]
+    },
+    {
+      "scriptId": "52",
+      "url": "file:///TEST_CWD/test/fixtures/all/vanilla/LOADED.js",
+      "functions": [
+        {
+          "functionName": "",
+          "ranges": [
+            {
+              "startOffset": 0,
+              "endOffset": 309,
+              "count": 1
+            }
+          ],
+          "isBlockCoverage": true
+        },
+        {
+          "functionName": "getString",
+          "ranges": [
+            {
+              "startOffset": 17,
+              "endOffset": 309,
+              "count": 3
+            },
+            {
+              "startOffset": 89,
+              "endOffset": 117,
+              "count": 0
+            },
+            {
+              "startOffset": 140,
+              "endOffset": 169,
+              "count": 1
+            },
+            {
+              "startOffset": 169,
+              "endOffset": 267,
+              "count": 2
+            },
+            {
+              "startOffset": 190,
+              "endOffset": 267,
+              "count": 1
+            },
+            {
+              "startOffset": 272,
+              "endOffset": 306,
+              "count": 0
+            }
+          ],
+          "isBlockCoverage": true
+        }
+      ]
+    }
+    ]
+}

--- a/test/integration.js.snap
+++ b/test/integration.js.snap
@@ -88,6 +88,20 @@ exports[`c8 --all should allow for --all to be used with the check-coverage comm
 "
 `;
 
+exports[`c8 --all should, given path casing mismatches between path.resolve and v8 output, NOT contain duplicate report entries 1`] = `
+",--------------|---------|----------|---------|---------|-------------------
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+--------------|---------|----------|---------|---------|-------------------
+All files     |   64.29 |    66.67 |      50 |   64.29 |                   
+ vanilla      |   78.26 |       75 |     100 |   78.26 |                   
+  LOADED.js   |   73.68 |    71.43 |     100 |   73.68 | 4,5,16-18         
+  MAIN.js     |     100 |      100 |     100 |     100 |                   
+ vanilla/dir  |       0 |        0 |       0 |       0 |                   
+  unloaded.js |       0 |        0 |       0 |       0 | 1-5               
+--------------|---------|----------|---------|---------|-------------------
+,"
+`;
+
 exports[`c8 ESM Modules collects coverage for ESM modules 1`] = `
 ",bar foo
 ------------|---------|----------|---------|---------|-------------------

--- a/test/path-set.js
+++ b/test/path-set.js
@@ -1,0 +1,38 @@
+/* global describe, it */
+const PathSet = require('../lib/path-set')
+const assert = require('assert')
+describe('path-set', () => {
+  it('should have only one entry when adding strings with different cases on win32', () => {
+    const pathSet = new PathSet()
+    pathSet._win32 = true
+    const file = 'foo.js'
+    pathSet.add(file)
+    pathSet.add(file.toUpperCase())
+    assert.strictEqual(pathSet.size, 1)
+  })
+
+  it('should have multiple entries when adding strings with different cases on non-win32', () => {
+    const pathSet = new PathSet()
+    pathSet._win32 = false
+    const file = 'foo.js'
+    pathSet.add(file)
+    pathSet.add(file.toUpperCase())
+    assert.strictEqual(pathSet.size, 2)
+  })
+
+  it('has should return true for different cases on win32', () => {
+    const pathSet = new PathSet()
+    pathSet._win32 = true
+    const file = 'foo.js'
+    pathSet.add(file)
+    assert(pathSet.has(file.toUpperCase()))
+  })
+
+  it('has should NOT return true for different cases non-win32', () => {
+    const pathSet = new PathSet()
+    pathSet._win32 = false
+    const file = 'foo.js'
+    pathSet.add(file)
+    assert(!pathSet.has(file.toUpperCase()))
+  })
+})


### PR DESCRIPTION
I found that on win32, if the v8 script name was set using "legal" (I'm using that term loosely, because it probably shouldn't be done by the embedder), but mismatched casing for a file path, it would result in `--all` reporting duplicate records for an entry. 

For example where node's `path.resolve` might provide you with `c:\src\main.js` it would be perfectly fine on windows to tell v8 that the script resource was `c:\src\MAIN.js`. If you then try to measure coverage with all, the mismatch in casing between v8's blobs and node's file system results cause the system to report duplicate empty records for files that are actually in the blobs, just differ on case.

Prior to my fix test output vs the correct snapshot  would like like:

```
     AssertionError: expected value to match snapshot c8 --all should, given path casing mismatches between path.resolve and v8 output, NOT contain duplicate report entries 1
      + expected - actual

       ",--------------|---------|----------|---------|---------|-------------------
       File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
       --------------|---------|----------|---------|---------|-------------------
      -All files     |   35.29 |    54.55 |      25 |   35.29 |                   
      - vanilla      |   39.13 |       60 |   33.33 |   39.13 |                   
      +All files     |   64.29 |    66.67 |      50 |   64.29 |                   
      + vanilla      |   78.26 |       75 |     100 |   78.26 |                   
         LOADED.js   |   73.68 |    71.43 |     100 |   73.68 | 4,5,16-18
         MAIN.js     |     100 |      100 |     100 |     100 |
      -  loaded.js   |       0 |        0 |       0 |       0 | 1-19              
      -  main.js     |       0 |        0 |       0 |       0 | 1-4               
        vanilla/dir  |       0 |        0 |       0 |       0 |
         unloaded.js |       0 |        0 |       0 |       0 | 1-5
       --------------|---------|----------|---------|---------|-------------------
       ,"

      at Context.<anonymous> (test\integration.js:457:40)
      at processImmediate (internal/timers.js:439:21)
```



##### Checklist
- [ x ] `npm test`, tests passing
- [ x ] `npm run test:snap` (to update the snapshot)
- [ x ] tests and/or benchmarks are included
- [ ] documentation is changed or added
