### PR TITLE
feat: Allow --all to support multiple directories from Report

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,8 @@ export declare class Report {
         wrapperLength?: number,
         resolve?: string,
         all?: boolean,
+        src?: Array<string>,
+        allowExternal: boolean
     })
-
     run(): Promise<void>;
 }

--- a/lib/report.js
+++ b/lib/report.js
@@ -21,7 +21,9 @@ class Report {
     omitRelative,
     wrapperLength,
     resolve: resolvePaths,
-    all
+    all,
+    src,
+    allowExternal = false
   }) {
     this.reporter = reporter
     this.reportsDirectory = reportsDirectory
@@ -30,13 +32,24 @@ class Report {
     this.resolve = resolvePaths
     this.exclude = new Exclude({
       exclude: exclude,
-      include: include
+      include: include,
+      relativePath: !allowExternal
     })
     this.omitRelative = omitRelative
     this.sourceMapCache = {}
     this.wrapperLength = wrapperLength
     this.all = all
-    this.src = process.cwd()
+    this.src = this.getSrc(src)
+  }
+
+  getSrc (src) {
+    if (typeof src === 'string') {
+      return [src]
+    } else if (Array.isArray(src)) {
+      return src
+    } else {
+      return [process.cwd()]
+    }
   }
 
   async run () {
@@ -159,33 +172,35 @@ class Report {
       v8ProcessCovs.unshift({
         result: emptyReports
       })
-      const workingDir = process.cwd()
-      this.exclude.globSync(workingDir).forEach((f) => {
-        const fullPath = resolve(workingDir, f)
-        if (!fileIndex.has(fullPath)) {
-          const ext = extname(f)
-          if (ext === '.js' || ext === '.ts' || ext === '.mjs') {
-            const stat = statSync(f)
-            const sourceMap = getSourceMapFromFile(f)
-            if (sourceMap !== undefined) {
-              this.sourceMapCache[`file://${fullPath}`] = { data: JSON.parse(readFileSync(sourceMap).toString()) }
+      const workingDirs = this.src
+      for (const workingDir of workingDirs) {
+        this.exclude.globSync(workingDir).forEach((f) => {
+          const fullPath = resolve(workingDir, f)
+          if (!fileIndex.has(fullPath)) {
+            const ext = extname(f)
+            if (ext === '.js' || ext === '.ts' || ext === '.mjs') {
+              const stat = statSync(f)
+              const sourceMap = getSourceMapFromFile(f)
+              if (sourceMap !== undefined) {
+                this.sourceMapCache[`file://${fullPath}`] = { data: JSON.parse(readFileSync(sourceMap).toString()) }
+              }
+              emptyReports.push({
+                scriptId: 0,
+                url: resolve(f),
+                functions: [{
+                  functionName: '(empty-report)',
+                  ranges: [{
+                    startOffset: 0,
+                    endOffset: stat.size,
+                    count: 0
+                  }],
+                  isBlockCoverage: true
+                }]
+              })
             }
-            emptyReports.push({
-              scriptId: 0,
-              url: resolve(f),
-              functions: [{
-                functionName: '(empty-report)',
-                ranges: [{
-                  startOffset: 0,
-                  endOffset: stat.size,
-                  count: 0
-                }],
-                isBlockCoverage: true
-              }]
-            })
           }
-        }
-      })
+        })
+      }
     }
 
     return mergeProcessCovs(v8ProcessCovs)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

****DRAFT: 

We're currently leveraging the `index.js` programmatically via `require("c8")` for a build system that is bit non standard in that multiple `dist` directories for various projects can be leveraged in a workspace that is outside the cwd of where the test are run. 

This change modifies the interface to `Report` but not the CLI in the following ways:

* It allows `src` to be supplied as a Array of string paths. 
* If `src` isn't supplied, src is overriden to the default `cwd`, the main CLI doesn't currently allow these directories to be supplied to avoid over complicating the CLI interface.
* An additional flag for `allowExternal` is supplied and passed to `test-exlude` to indicate that not all paths will be relative. Not supplying this flag causes `test-exclude` to reject anything outside of `cwd`.
 
Please don't merge this just yet as I'm still testing, writing tests. But I wanted to get your thoughts if this was a feasible enhancement.

This yea

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x ] `npm test`, tests passing
- [ ] `npm run test:snap` (to update the snapshot)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
