### PR TITLE
chore: simplify config loader

### DIFF
--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -1,11 +1,12 @@
 const defaultExclude = require('@istanbuljs/schema/default-exclude')
-const findUp = require('find-up')
+const escalade = require('escalade/sync')
 const { readFileSync } = require('fs')
 const Yargs = require('yargs/yargs')
 const parser = require('yargs-parser')
 const { resolve } = require('path')
 
-const configPath = findUp.sync(['.c8rc', '.c8rc.json', '.nycrc', '.nycrc.json'])
+const configFiles = ['.c8rc', '.c8rc.json', '.nycrc', '.nycrc.json']
+const configPath = escalade('.', (dir, names) => configFiles.find(x => names.includes(x)))
 const config = configPath ? JSON.parse(readFileSync(configPath)) : {}
 
 function buildYargs (withCommands = false) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -553,6 +553,11 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "escalade": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-1.0.0.tgz",
+      "integrity": "sha512-WvKmjtpItFC/A7e7XmgTv1bjoJRGirq6fTiV5MK9bmqD0fzWnH1AaVEby0dd3m9XVESNLrnPemSn5G9xcJn1UQ=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@bcoe/v8-coverage": "^0.2.3",
     "@istanbuljs/schema": "^0.1.2",
-    "find-up": "^4.0.0",
+    "escalade": "^1.0.0",
     "foreground-child": "^2.0.0",
     "furi": "^2.0.0",
     "istanbul-lib-coverage": "^3.0.0",


### PR DESCRIPTION
Hey there, thank you for `c8` :)

I was trying to figure out how it works recently & noticed you're loading 7 dependencies to hunt for a config file.
While it's not a _significant_ part of your dependency chain, it's still a [branch that can be removed](https://npm.anvaka.com/#!/view/2d/c8).

Instead, `escalade` is 21 lines of code and has no dependencies. It's also [faster than `find-up`](https://github.com/lukeed/escalade#benchmarks) and supports native ESM when `c8` moves its source that way.

There's also a security advantage – `find-up` will continue traversal into your `/` directory (wtf) before giving up. Escalade stops at the `process.cwd()` directory, which one would expect...

FWIW, I may have just _released_ `"escalade"` but I've been using this internally for a while.
Didn't set out to replace `find-up`, but once these comparison points dawned on me, I figured it needs sharing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist

- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)
