### PR TITLE
feat: use debuglog rather than console.warn

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -9,6 +9,8 @@ const getSourceMapFromFile = require('./source-map-from-file')
 // TODO: switch back to @c88/v8-coverage once patch is landed.
 const v8toIstanbul = require('v8-to-istanbul')
 const isCjsEsmBridgeCov = require('./is-cjs-esm-bridge')
+const util = require('util')
+const debuglog = util.debuglog('c8')
 
 class Report {
   constructor ({
@@ -103,7 +105,7 @@ class Report {
           map.merge(converter.toIstanbul())
         }
       } catch (err) {
-        console.warn(`file: ${v8ScriptCov.url} error: ${err.stack}`)
+        debuglog(`file: ${v8ScriptCov.url} error: ${err.stack}`)
       }
     }
 
@@ -233,7 +235,7 @@ class Report {
           'utf8'
         )))
       } catch (err) {
-        console.warn(`${err.stack}`)
+        debuglog(`${err.stack}`)
       }
     }
     return reports
@@ -268,7 +270,7 @@ class Report {
           v8ScriptCov.url = furi.toSysPath(v8ScriptCov.url)
           fileIndex.add(v8ScriptCov.url)
         } catch (err) {
-          console.warn(err)
+          debuglog(`${err.stack}`)
           continue
         }
       }

--- a/test/integration.js
+++ b/test/integration.js
@@ -79,7 +79,9 @@ describe('c8', () => {
       '--clean=false',
       nodePath,
       require.resolve('./fixtures/multiple-spawn')
-    ])
+    ], {
+      env: { NODE_DEBUG: 'c8' }
+    })
     output.toString('utf8').should.match(
       /Error: ENOENT: no such file or directory.*loaders\.js/
     )

--- a/test/integration.js_10.snap
+++ b/test/integration.js_10.snap
@@ -139,13 +139,13 @@ hey
 --------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |   75.69 |    58.23 |   66.67 |   75.69 |                                
+All files                 |   75.76 |    58.23 |   66.67 |   75.76 |                                
  bin                      |   78.85 |       60 |   66.67 |   78.85 |                                
   c8.js                   |   78.85 |       60 |   66.67 |   78.85 | 22,27-29,32-33,41-43,50-51     
- lib                      |   80.67 |    51.85 |   83.33 |   80.67 |                                
+ lib                      |   80.75 |    51.85 |   83.33 |   80.75 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
   parse-args.js           |   96.13 |    45.45 |     100 |   96.13 | 109-110,118-119,132-133        
-  report.js               |   75.17 |    58.82 |   83.33 |   75.17 | ...206,236-237,264-265,271-273 
+  report.js               |   75.35 |    58.82 |   83.33 |   75.35 | ...208,238-239,266-267,273-275 
   source-map-from-file.js |      44 |      100 |       0 |      44 | 10-23                          
  lib/commands             |   44.44 |       75 |   16.67 |   44.44 |                                
   check-coverage.js       |   21.31 |      100 |       0 |   21.31 | 9-11,14-27,30-44,46-61         
@@ -154,9 +154,9 @@ All files                 |   75.69 |    58.23 |   66.67 |   75.69 |
   async.js                |     100 |      100 |     100 |     100 |                                
   normal.js               |      75 |    66.67 |   33.33 |      75 | 14-16,18-20                    
 --------------------------|---------|----------|---------|---------|--------------------------------
-,ERROR: Coverage for lines (75.69%) does not meet global threshold (101%)
+,ERROR: Coverage for lines (75.76%) does not meet global threshold (101%)
 ERROR: Coverage for branches (58.23%) does not meet global threshold (82%)
-ERROR: Coverage for statements (75.69%) does not meet global threshold (95%)
+ERROR: Coverage for statements (75.76%) does not meet global threshold (95%)
 "
 `;
 
@@ -174,9 +174,9 @@ ERROR: Coverage for branches (25%) does not meet threshold (82%) for lib/is-cjs-
 ERROR: Coverage for statements (90%) does not meet threshold (95%) for lib/is-cjs-esm-bridge.js
 ERROR: Coverage for lines (96.13%) does not meet threshold (101%) for lib/parse-args.js
 ERROR: Coverage for branches (45.45%) does not meet threshold (82%) for lib/parse-args.js
-ERROR: Coverage for lines (75.17%) does not meet threshold (101%) for lib/report.js
+ERROR: Coverage for lines (75.35%) does not meet threshold (101%) for lib/report.js
 ERROR: Coverage for branches (58.82%) does not meet threshold (82%) for lib/report.js
-ERROR: Coverage for statements (75.17%) does not meet threshold (95%) for lib/report.js
+ERROR: Coverage for statements (75.35%) does not meet threshold (95%) for lib/report.js
 ERROR: Coverage for lines (44%) does not meet threshold (101%) for lib/source-map-from-file.js
 ERROR: Coverage for statements (44%) does not meet threshold (95%) for lib/source-map-from-file.js
 ERROR: Coverage for lines (100%) does not meet threshold (101%) for test/fixtures/async.js
@@ -189,9 +189,9 @@ ERROR: Coverage for statements (75%) does not meet threshold (95%) for test/fixt
 exports[`c8 check-coverage exits with 0 if coverage within threshold 1`] = `",,"`;
 
 exports[`c8 check-coverage exits with 1 if coverage is below threshold 1`] = `
-",,ERROR: Coverage for lines (75.69%) does not meet global threshold (101%)
+",,ERROR: Coverage for lines (75.76%) does not meet global threshold (101%)
 ERROR: Coverage for branches (58.23%) does not meet global threshold (82%)
-ERROR: Coverage for statements (75.69%) does not meet global threshold (95%)
+ERROR: Coverage for statements (75.76%) does not meet global threshold (95%)
 "
 `;
 
@@ -274,13 +274,13 @@ exports[`c8 report generates report from existing temporary files 1`] = `
 ",--------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |   75.69 |    58.23 |   66.67 |   75.69 |                                
+All files                 |   75.76 |    58.23 |   66.67 |   75.76 |                                
  bin                      |   78.85 |       60 |   66.67 |   78.85 |                                
   c8.js                   |   78.85 |       60 |   66.67 |   78.85 | 22,27-29,32-33,41-43,50-51     
- lib                      |   80.67 |    51.85 |   83.33 |   80.67 |                                
+ lib                      |   80.75 |    51.85 |   83.33 |   80.75 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
   parse-args.js           |   96.13 |    45.45 |     100 |   96.13 | 109-110,118-119,132-133        
-  report.js               |   75.17 |    58.82 |   83.33 |   75.17 | ...206,236-237,264-265,271-273 
+  report.js               |   75.35 |    58.82 |   83.33 |   75.35 | ...208,238-239,266-267,273-275 
   source-map-from-file.js |      44 |      100 |       0 |      44 | 10-23                          
  lib/commands             |   44.44 |       75 |   16.67 |   44.44 |                                
   check-coverage.js       |   21.31 |      100 |       0 |   21.31 | 9-11,14-27,30-44,46-61         
@@ -296,13 +296,13 @@ exports[`c8 report supports --check-coverage, when generating reports 1`] = `
 ",--------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |   75.69 |    58.23 |   66.67 |   75.69 |                                
+All files                 |   75.76 |    58.23 |   66.67 |   75.76 |                                
  bin                      |   78.85 |       60 |   66.67 |   78.85 |                                
   c8.js                   |   78.85 |       60 |   66.67 |   78.85 | 22,27-29,32-33,41-43,50-51     
- lib                      |   80.67 |    51.85 |   83.33 |   80.67 |                                
+ lib                      |   80.75 |    51.85 |   83.33 |   80.75 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
   parse-args.js           |   96.13 |    45.45 |     100 |   96.13 | 109-110,118-119,132-133        
-  report.js               |   75.17 |    58.82 |   83.33 |   75.17 | ...206,236-237,264-265,271-273 
+  report.js               |   75.35 |    58.82 |   83.33 |   75.35 | ...208,238-239,266-267,273-275 
   source-map-from-file.js |      44 |      100 |       0 |      44 | 10-23                          
  lib/commands             |   44.44 |       75 |   16.67 |   44.44 |                                
   check-coverage.js       |   21.31 |      100 |       0 |   21.31 | 9-11,14-27,30-44,46-61         
@@ -311,9 +311,9 @@ All files                 |   75.69 |    58.23 |   66.67 |   75.69 |
   async.js                |     100 |      100 |     100 |     100 |                                
   normal.js               |      75 |    66.67 |   33.33 |      75 | 14-16,18-20                    
 --------------------------|---------|----------|---------|---------|--------------------------------
-,ERROR: Coverage for lines (75.69%) does not meet global threshold (101%)
+,ERROR: Coverage for lines (75.76%) does not meet global threshold (101%)
 ERROR: Coverage for branches (58.23%) does not meet global threshold (82%)
-ERROR: Coverage for statements (75.69%) does not meet global threshold (95%)
+ERROR: Coverage for statements (75.76%) does not meet global threshold (95%)
 "
 `;
 


### PR DESCRIPTION
These warnings were creating a lot of confusion for when running coverage on the Node.js project.

Rather than always outputting warnings, let's allow people to opt into seeing warnings if they set `NODE_DEBUG=c8`.