### PR TITLE
fix: address bugs with source remapping on Windows

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -1,10 +1,10 @@
 const Exclude = require('test-exclude')
-const furi = require('furi')
 const libCoverage = require('istanbul-lib-coverage')
 const libReport = require('istanbul-lib-report')
 const reports = require('istanbul-reports')
 const { readdirSync, readFileSync, statSync } = require('fs')
 const { isAbsolute, resolve, extname } = require('path')
+const { pathToFileURL, fileURLToPath } = require('url')
 const getSourceMapFromFile = require('./source-map-from-file')
 // TODO: switch back to @c88/v8-coverage once patch is landed.
 const v8toIstanbul = require('v8-to-istanbul')
@@ -139,8 +139,8 @@ class Report {
    */
   _getSourceMap (v8ScriptCov) {
     const sources = {}
-    if (this.sourceMapCache[`file://${v8ScriptCov.url}`]) {
-      const sourceMapAndLineLengths = this.sourceMapCache[`file://${v8ScriptCov.url}`]
+    const sourceMapAndLineLengths = this.sourceMapCache[pathToFileURL(v8ScriptCov.url).href]
+    if (sourceMapAndLineLengths) {
       // See: https://github.com/nodejs/node/pull/34305
       if (!sourceMapAndLineLengths.data) return
       sources.sourceMap = {
@@ -173,7 +173,7 @@ class Report {
     for (const v8ProcessCov of this._loadReports()) {
       if (this._isCoverageObject(v8ProcessCov)) {
         if (v8ProcessCov['source-map-cache']) {
-          Object.assign(this.sourceMapCache, v8ProcessCov['source-map-cache'])
+          Object.assign(this.sourceMapCache, this._normalizeSourceMapCache(v8ProcessCov['source-map-cache']))
         }
         v8ProcessCovs.push(this._normalizeProcessCov(v8ProcessCov, fileIndex))
       }
@@ -194,7 +194,7 @@ class Report {
               const stat = statSync(fullPath)
               const sourceMap = getSourceMapFromFile(fullPath)
               if (sourceMap) {
-                this.sourceMapCache[`file://${fullPath}`] = { data: sourceMap }
+                this.sourceMapCache[pathToFileURL(fullPath)] = { data: sourceMap }
               }
               emptyReports.push({
                 scriptId: 0,
@@ -275,7 +275,7 @@ class Report {
       }
       if (/^file:\/\//.test(v8ScriptCov.url)) {
         try {
-          v8ScriptCov.url = furi.toSysPath(v8ScriptCov.url)
+          v8ScriptCov.url = fileURLToPath(v8ScriptCov.url)
           fileIndex.add(v8ScriptCov.url)
         } catch (err) {
           debuglog(`${err.stack}`)
@@ -289,6 +289,23 @@ class Report {
       }
     }
     return { result }
+  }
+
+  /**
+   * Normalizes a V8 source map cache.
+   *
+   * This function normalizes file URLs to a system-independent format.
+   *
+   * @param v8SourceMapCache V8 source map cache to normalize.
+   * @return {v8SourceMapCache} Normalized V8 source map cache.
+   * @private
+   */
+  _normalizeSourceMapCache (v8SourceMapCache) {
+    const cache = {}
+    for (const fileURL of Object.keys(v8SourceMapCache)) {
+      cache[pathToFileURL(fileURLToPath(fileURL)).href] = v8SourceMapCache[fileURL]
+    }
+    return cache
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,11 +79,6 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="
     },
-    "@types/is-windows": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-1.0.0.tgz",
-      "integrity": "sha512-tJ1rq04tGKuIJoWIH0Gyuwv4RQ3+tIu7wQrC0MV47raQ44kIzXSSFKfrxFUOWVRvesoF7mrTqigXmqoZJsXwTg=="
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -1047,15 +1042,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "furi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/furi/-/furi-2.0.0.tgz",
-      "integrity": "sha512-uKuNsaU0WVaK/vmvj23wW1bicOFfyqSsAIH71bRZx8kA4Xj+YCHin7CJKJJjkIsmxYaPFLk9ljmjEyB7xF7WvQ==",
-      "requires": {
-        "@types/is-windows": "^1.0.0",
-        "is-windows": "^1.0.2"
-      }
-    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1336,11 +1322,6 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
-    },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "isarray": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@istanbuljs/schema": "^0.1.2",
     "find-up": "^5.0.0",
     "foreground-child": "^2.0.0",
-    "furi": "^2.0.0",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.0.2",

--- a/test/integration.js_10.snap
+++ b/test/integration.js_10.snap
@@ -152,13 +152,13 @@ hey
 --------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |   73.17 |    58.02 |   62.16 |   73.17 |                                
+All files                 |   73.12 |    58.02 |   60.53 |   73.12 |                                
  bin                      |   78.85 |       60 |   66.67 |   78.85 |                                
   c8.js                   |   78.85 |       60 |   66.67 |   78.85 | 22,27-29,32-33,41-43,50-51     
- lib                      |   76.44 |    51.79 |   72.73 |   76.44 |                                
+ lib                      |   76.27 |    51.79 |   69.57 |   76.27 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
   parse-args.js           |   96.39 |    45.45 |     100 |   96.39 | 120-121,129-130,143-144        
-  report.js               |   75.42 |    58.33 |   84.62 |   75.42 | ...216,246-247,274-275,281-283 
+  report.js               |   75.16 |    58.33 |   78.57 |   75.16 | ...247,274-275,281-283,304-309 
   source-map-from-file.js |      45 |      100 |       0 |      45 | 39-50,52-67,69-77,81-98        
  lib/commands             |   45.65 |       75 |   16.67 |   45.65 |                                
   check-coverage.js       |   21.31 |      100 |       0 |   21.31 | 9-11,14-27,30-44,46-61         
@@ -167,9 +167,9 @@ All files                 |   73.17 |    58.02 |   62.16 |   73.17 |
   async.js                |     100 |      100 |     100 |     100 |                                
   normal.js               |      75 |    66.67 |   33.33 |      75 | 14-16,18-20                    
 --------------------------|---------|----------|---------|---------|--------------------------------
-,ERROR: Coverage for lines (73.17%) does not meet global threshold (101%)
+,ERROR: Coverage for lines (73.12%) does not meet global threshold (101%)
 ERROR: Coverage for branches (58.02%) does not meet global threshold (82%)
-ERROR: Coverage for statements (73.17%) does not meet global threshold (95%)
+ERROR: Coverage for statements (73.12%) does not meet global threshold (95%)
 "
 `;
 
@@ -187,9 +187,9 @@ ERROR: Coverage for branches (25%) does not meet threshold (82%) for lib/is-cjs-
 ERROR: Coverage for statements (90%) does not meet threshold (95%) for lib/is-cjs-esm-bridge.js
 ERROR: Coverage for lines (96.39%) does not meet threshold (101%) for lib/parse-args.js
 ERROR: Coverage for branches (45.45%) does not meet threshold (82%) for lib/parse-args.js
-ERROR: Coverage for lines (75.42%) does not meet threshold (101%) for lib/report.js
+ERROR: Coverage for lines (75.16%) does not meet threshold (101%) for lib/report.js
 ERROR: Coverage for branches (58.33%) does not meet threshold (82%) for lib/report.js
-ERROR: Coverage for statements (75.42%) does not meet threshold (95%) for lib/report.js
+ERROR: Coverage for statements (75.16%) does not meet threshold (95%) for lib/report.js
 ERROR: Coverage for lines (45%) does not meet threshold (101%) for lib/source-map-from-file.js
 ERROR: Coverage for statements (45%) does not meet threshold (95%) for lib/source-map-from-file.js
 ERROR: Coverage for lines (100%) does not meet threshold (101%) for test/fixtures/async.js
@@ -202,9 +202,9 @@ ERROR: Coverage for statements (75%) does not meet threshold (95%) for test/fixt
 exports[`c8 check-coverage exits with 0 if coverage within threshold 1`] = `",,"`;
 
 exports[`c8 check-coverage exits with 1 if coverage is below threshold 1`] = `
-",,ERROR: Coverage for lines (73.17%) does not meet global threshold (101%)
+",,ERROR: Coverage for lines (73.12%) does not meet global threshold (101%)
 ERROR: Coverage for branches (58.02%) does not meet global threshold (82%)
-ERROR: Coverage for statements (73.17%) does not meet global threshold (95%)
+ERROR: Coverage for statements (73.12%) does not meet global threshold (95%)
 "
 `;
 
@@ -287,13 +287,13 @@ exports[`c8 report generates report from existing temporary files 1`] = `
 ",--------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |   73.17 |    58.02 |   62.16 |   73.17 |                                
+All files                 |   73.12 |    58.02 |   60.53 |   73.12 |                                
  bin                      |   78.85 |       60 |   66.67 |   78.85 |                                
   c8.js                   |   78.85 |       60 |   66.67 |   78.85 | 22,27-29,32-33,41-43,50-51     
- lib                      |   76.44 |    51.79 |   72.73 |   76.44 |                                
+ lib                      |   76.27 |    51.79 |   69.57 |   76.27 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
   parse-args.js           |   96.39 |    45.45 |     100 |   96.39 | 120-121,129-130,143-144        
-  report.js               |   75.42 |    58.33 |   84.62 |   75.42 | ...216,246-247,274-275,281-283 
+  report.js               |   75.16 |    58.33 |   78.57 |   75.16 | ...247,274-275,281-283,304-309 
   source-map-from-file.js |      45 |      100 |       0 |      45 | 39-50,52-67,69-77,81-98        
  lib/commands             |   45.65 |       75 |   16.67 |   45.65 |                                
   check-coverage.js       |   21.31 |      100 |       0 |   21.31 | 9-11,14-27,30-44,46-61         
@@ -309,13 +309,13 @@ exports[`c8 report supports --check-coverage, when generating reports 1`] = `
 ",--------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |   73.17 |    58.02 |   62.16 |   73.17 |                                
+All files                 |   73.12 |    58.02 |   60.53 |   73.12 |                                
  bin                      |   78.85 |       60 |   66.67 |   78.85 |                                
   c8.js                   |   78.85 |       60 |   66.67 |   78.85 | 22,27-29,32-33,41-43,50-51     
- lib                      |   76.44 |    51.79 |   72.73 |   76.44 |                                
+ lib                      |   76.27 |    51.79 |   69.57 |   76.27 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
   parse-args.js           |   96.39 |    45.45 |     100 |   96.39 | 120-121,129-130,143-144        
-  report.js               |   75.42 |    58.33 |   84.62 |   75.42 | ...216,246-247,274-275,281-283 
+  report.js               |   75.16 |    58.33 |   78.57 |   75.16 | ...247,274-275,281-283,304-309 
   source-map-from-file.js |      45 |      100 |       0 |      45 | 39-50,52-67,69-77,81-98        
  lib/commands             |   45.65 |       75 |   16.67 |   45.65 |                                
   check-coverage.js       |   21.31 |      100 |       0 |   21.31 | 9-11,14-27,30-44,46-61         
@@ -324,9 +324,9 @@ All files                 |   73.17 |    58.02 |   62.16 |   73.17 |
   async.js                |     100 |      100 |     100 |     100 |                                
   normal.js               |      75 |    66.67 |   33.33 |      75 | 14-16,18-20                    
 --------------------------|---------|----------|---------|---------|--------------------------------
-,ERROR: Coverage for lines (73.17%) does not meet global threshold (101%)
+,ERROR: Coverage for lines (73.12%) does not meet global threshold (101%)
 ERROR: Coverage for branches (58.02%) does not meet global threshold (82%)
-ERROR: Coverage for statements (73.17%) does not meet global threshold (95%)
+ERROR: Coverage for statements (73.12%) does not meet global threshold (95%)
 "
 `;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `npm test`, tests passing
- [ ] `npm run test:snap` (to update the snapshot)

Fixes #300 with the fix outline in the issue.

As mentioned in the issue, fixing it reveals an upstream bug that causes test to fail. I have verified that on both node v14.16.1 and v16.0.0:

- Tests pass on Linux (docker)
- Locally linking to a fixed version of `v8-to-istanbul` makes tests pass on Windows