### PR TITLE
feat: add --exclude-node-modules option

### DIFF
--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -24,7 +24,8 @@ exports.outputReport = async function (argv) {
     all: argv.all,
     allowExternal: argv.allowExternal,
     src: argv.src,
-    skipFull: argv.skipFull
+    skipFull: argv.skipFull,
+    excludeNodeModules: argv.excludeNodeModules
   })
   await report.run()
   if (argv.checkCoverage) await checkCoverages(argv, report)

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -41,6 +41,11 @@ function buildYargs (withCommands = false) {
       describe: 'supplying --src will override cwd as the default location where --all looks for src files. --src can be ' +
         'supplied multiple times and each directory will be included. This allows for workspaces spanning multiple projects'
     })
+    .option('exclude-node-modules', {
+      default: true,
+      type: 'boolean',
+      describe: 'whether or not to exclude all node_module folders (i.e. **/node_modules/**) by default'
+    })
     .option('include', {
       alias: 'n',
       default: [],

--- a/lib/report.js
+++ b/lib/report.js
@@ -27,7 +27,8 @@ class Report {
     all,
     src,
     allowExternal = false,
-    skipFull
+    skipFull,
+    excludeNodeModules
   }) {
     this.reporter = reporter
     this.reportsDirectory = reportsDirectory
@@ -37,7 +38,8 @@ class Report {
     this.exclude = new Exclude({
       exclude: exclude,
       include: include,
-      relativePath: !allowExternal
+      relativePath: !allowExternal,
+      excludeNodeModules: excludeNodeModules
     })
     this.excludeAfterRemap = excludeAfterRemap
     this.omitRelative = omitRelative

--- a/test/integration.js_10.snap
+++ b/test/integration.js_10.snap
@@ -152,24 +152,24 @@ hey
 --------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |    73.7 |    59.76 |    62.5 |    73.7 |                                
+All files                 |   73.96 |    59.76 |    62.5 |   73.96 |                                
  bin                      |   78.85 |       60 |   66.67 |   78.85 |                                
   c8.js                   |   78.85 |       60 |   66.67 |   78.85 | 22,27-29,32-33,41-43,50-51     
- lib                      |   76.94 |    54.39 |      72 |   76.94 |                                
+ lib                      |    77.2 |    54.39 |      72 |    77.2 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
-  parse-args.js           |   96.72 |    58.33 |     100 |   96.72 | 137-138,146-147,160-161        
-  report.js               |   75.16 |    58.33 |   78.57 |   75.16 | ...247,274-275,281-283,304-309 
+  parse-args.js           |   96.81 |    58.33 |     100 |   96.81 | 142-143,151-152,165-166        
+  report.js               |   75.32 |    58.33 |   78.57 |   75.32 | ...249,276-277,283-285,306-311 
   source-map-from-file.js |      45 |      100 |       0 |      45 | 39-50,52-67,69-77,81-98        
- lib/commands             |   45.65 |       75 |   16.67 |   45.65 |                                
+ lib/commands             |   46.24 |       75 |   16.67 |   46.24 |                                
   check-coverage.js       |   21.31 |      100 |       0 |   21.31 | 9-11,14-27,30-44,46-61         
-  report.js               |   93.55 |    71.43 |      50 |   93.55 | 9-10                           
+  report.js               |   93.75 |    71.43 |      50 |   93.75 | 9-10                           
  test/fixtures            |   83.33 |    85.71 |   66.67 |   83.33 |                                
   async.js                |     100 |      100 |     100 |     100 |                                
   normal.js               |      75 |    66.67 |   33.33 |      75 | 14-16,18-20                    
 --------------------------|---------|----------|---------|---------|--------------------------------
-,ERROR: Coverage for lines (73.7%) does not meet global threshold (101%)
+,ERROR: Coverage for lines (73.96%) does not meet global threshold (101%)
 ERROR: Coverage for branches (59.76%) does not meet global threshold (82%)
-ERROR: Coverage for statements (73.7%) does not meet global threshold (95%)
+ERROR: Coverage for statements (73.96%) does not meet global threshold (95%)
 "
 `;
 
@@ -179,17 +179,17 @@ ERROR: Coverage for branches (60%) does not meet threshold (82%) for bin/c8.js
 ERROR: Coverage for statements (78.85%) does not meet threshold (95%) for bin/c8.js
 ERROR: Coverage for lines (21.31%) does not meet threshold (101%) for lib/commands/check-coverage.js
 ERROR: Coverage for statements (21.31%) does not meet threshold (95%) for lib/commands/check-coverage.js
-ERROR: Coverage for lines (93.55%) does not meet threshold (101%) for lib/commands/report.js
+ERROR: Coverage for lines (93.75%) does not meet threshold (101%) for lib/commands/report.js
 ERROR: Coverage for branches (71.43%) does not meet threshold (82%) for lib/commands/report.js
-ERROR: Coverage for statements (93.55%) does not meet threshold (95%) for lib/commands/report.js
+ERROR: Coverage for statements (93.75%) does not meet threshold (95%) for lib/commands/report.js
 ERROR: Coverage for lines (90%) does not meet threshold (101%) for lib/is-cjs-esm-bridge.js
 ERROR: Coverage for branches (25%) does not meet threshold (82%) for lib/is-cjs-esm-bridge.js
 ERROR: Coverage for statements (90%) does not meet threshold (95%) for lib/is-cjs-esm-bridge.js
-ERROR: Coverage for lines (96.72%) does not meet threshold (101%) for lib/parse-args.js
+ERROR: Coverage for lines (96.81%) does not meet threshold (101%) for lib/parse-args.js
 ERROR: Coverage for branches (58.33%) does not meet threshold (82%) for lib/parse-args.js
-ERROR: Coverage for lines (75.16%) does not meet threshold (101%) for lib/report.js
+ERROR: Coverage for lines (75.32%) does not meet threshold (101%) for lib/report.js
 ERROR: Coverage for branches (58.33%) does not meet threshold (82%) for lib/report.js
-ERROR: Coverage for statements (75.16%) does not meet threshold (95%) for lib/report.js
+ERROR: Coverage for statements (75.32%) does not meet threshold (95%) for lib/report.js
 ERROR: Coverage for lines (45%) does not meet threshold (101%) for lib/source-map-from-file.js
 ERROR: Coverage for statements (45%) does not meet threshold (95%) for lib/source-map-from-file.js
 ERROR: Coverage for lines (100%) does not meet threshold (101%) for test/fixtures/async.js
@@ -202,9 +202,9 @@ ERROR: Coverage for statements (75%) does not meet threshold (95%) for test/fixt
 exports[`c8 check-coverage exits with 0 if coverage within threshold 1`] = `",,"`;
 
 exports[`c8 check-coverage exits with 1 if coverage is below threshold 1`] = `
-",,ERROR: Coverage for lines (73.7%) does not meet global threshold (101%)
+",,ERROR: Coverage for lines (73.96%) does not meet global threshold (101%)
 ERROR: Coverage for branches (59.76%) does not meet global threshold (82%)
-ERROR: Coverage for statements (73.7%) does not meet global threshold (95%)
+ERROR: Coverage for statements (73.96%) does not meet global threshold (95%)
 "
 `;
 
@@ -287,17 +287,17 @@ exports[`c8 report generates report from existing temporary files 1`] = `
 ",--------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |    73.7 |    59.76 |    62.5 |    73.7 |                                
+All files                 |   73.96 |    59.76 |    62.5 |   73.96 |                                
  bin                      |   78.85 |       60 |   66.67 |   78.85 |                                
   c8.js                   |   78.85 |       60 |   66.67 |   78.85 | 22,27-29,32-33,41-43,50-51     
- lib                      |   76.94 |    54.39 |      72 |   76.94 |                                
+ lib                      |    77.2 |    54.39 |      72 |    77.2 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
-  parse-args.js           |   96.72 |    58.33 |     100 |   96.72 | 137-138,146-147,160-161        
-  report.js               |   75.16 |    58.33 |   78.57 |   75.16 | ...247,274-275,281-283,304-309 
+  parse-args.js           |   96.81 |    58.33 |     100 |   96.81 | 142-143,151-152,165-166        
+  report.js               |   75.32 |    58.33 |   78.57 |   75.32 | ...249,276-277,283-285,306-311 
   source-map-from-file.js |      45 |      100 |       0 |      45 | 39-50,52-67,69-77,81-98        
- lib/commands             |   45.65 |       75 |   16.67 |   45.65 |                                
+ lib/commands             |   46.24 |       75 |   16.67 |   46.24 |                                
   check-coverage.js       |   21.31 |      100 |       0 |   21.31 | 9-11,14-27,30-44,46-61         
-  report.js               |   93.55 |    71.43 |      50 |   93.55 | 9-10                           
+  report.js               |   93.75 |    71.43 |      50 |   93.75 | 9-10                           
  test/fixtures            |   83.33 |    85.71 |   66.67 |   83.33 |                                
   async.js                |     100 |      100 |     100 |     100 |                                
   normal.js               |      75 |    66.67 |   33.33 |      75 | 14-16,18-20                    
@@ -309,24 +309,24 @@ exports[`c8 report supports --check-coverage, when generating reports 1`] = `
 ",--------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |    73.7 |    59.76 |    62.5 |    73.7 |                                
+All files                 |   73.96 |    59.76 |    62.5 |   73.96 |                                
  bin                      |   78.85 |       60 |   66.67 |   78.85 |                                
   c8.js                   |   78.85 |       60 |   66.67 |   78.85 | 22,27-29,32-33,41-43,50-51     
- lib                      |   76.94 |    54.39 |      72 |   76.94 |                                
+ lib                      |    77.2 |    54.39 |      72 |    77.2 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
-  parse-args.js           |   96.72 |    58.33 |     100 |   96.72 | 137-138,146-147,160-161        
-  report.js               |   75.16 |    58.33 |   78.57 |   75.16 | ...247,274-275,281-283,304-309 
+  parse-args.js           |   96.81 |    58.33 |     100 |   96.81 | 142-143,151-152,165-166        
+  report.js               |   75.32 |    58.33 |   78.57 |   75.32 | ...249,276-277,283-285,306-311 
   source-map-from-file.js |      45 |      100 |       0 |      45 | 39-50,52-67,69-77,81-98        
- lib/commands             |   45.65 |       75 |   16.67 |   45.65 |                                
+ lib/commands             |   46.24 |       75 |   16.67 |   46.24 |                                
   check-coverage.js       |   21.31 |      100 |       0 |   21.31 | 9-11,14-27,30-44,46-61         
-  report.js               |   93.55 |    71.43 |      50 |   93.55 | 9-10                           
+  report.js               |   93.75 |    71.43 |      50 |   93.75 | 9-10                           
  test/fixtures            |   83.33 |    85.71 |   66.67 |   83.33 |                                
   async.js                |     100 |      100 |     100 |     100 |                                
   normal.js               |      75 |    66.67 |   33.33 |      75 | 14-16,18-20                    
 --------------------------|---------|----------|---------|---------|--------------------------------
-,ERROR: Coverage for lines (73.7%) does not meet global threshold (101%)
+,ERROR: Coverage for lines (73.96%) does not meet global threshold (101%)
 ERROR: Coverage for branches (59.76%) does not meet global threshold (82%)
-ERROR: Coverage for statements (73.7%) does not meet global threshold (95%)
+ERROR: Coverage for statements (73.96%) does not meet global threshold (95%)
 "
 `;
 


### PR DESCRIPTION
Hello,

It's basically a trivial port of the --exclude-node-modules option from nyc.

Cheers,
Sergiy
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
