### PR TITLE
Adding `--extension` option, allowing override of defaults.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Here is a list of common options. Run `c8 --help` for the full list and document
 | `--all` | see [section below](#checking-for-full-source-coverage-using---all) for more info | `boolean` | `false` |
 | `--src` | see [section below](#checking-for-full-source-coverage-using---all) for more info | `Array<string>` | `[process.cwd()]`|
 | `-n`, `--include` | see [section below](#checking-for-full-source-coverage-using---all) for more info | `Array<string>` | `[]` (include all files) |
-| `-x`, `--exclude` | see [section below](#checking-for-full-source-coverage-using---all) for more info | `Array<string>` | [list](https://github.com/istanbuljs/schema/blob/main/default-exclude.js) |
+| `-x`, `--exclude` | see [section below](#checking-for-full-source-coverage-using---all) for more info | `Array<string>` | [list](https://github.com/istanbuljs/schema/blob/master/default-exclude.js) |
+| `--extension` | list of file extensions to be covered | `Array<string>` | [list](https://github.com/istanbuljs/schema/blob/master/default-extension.js) |
 | `--skip-full` | do not show files with 100% statement, branch, and function coverage | `boolean` | `false` |
 | `--check-coverage` | check whether coverage is within thresholds provided | `boolean` | `false` |
 | `--temp-directory` | directory V8 coverage data is written to and read from | `string` | `process.env.NODE_V8_COVERAGE` |

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -33,7 +33,8 @@ exports.outputReport = async function (argv) {
     allowExternal: argv.allowExternal,
     src: argv.src,
     skipFull: argv.skipFull,
-    excludeNodeModules: argv.excludeNodeModules
+    excludeNodeModules: argv.excludeNodeModules,
+    extension: argv.extension
   })
   await report.run()
   if (argv.checkCoverage) await checkCoverages(argv, report)

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -1,4 +1,5 @@
 const defaultExclude = require('@istanbuljs/schema/default-exclude')
+const defaultExtension = require('@istanbuljs/schema/default-extension')
 const findUp = require('find-up')
 const { readFileSync } = require('fs')
 const Yargs = require('yargs/yargs')
@@ -70,6 +71,11 @@ function buildYargs (withCommands = false) {
       type: 'boolean',
       group: 'Reporting options',
       describe: 'do not show files with 100% statement, branch, and function coverage'
+    })
+    .options('extension', {
+      default: defaultExtension,
+      group: 'Reporting options',
+      describe: 'a list of file extensions that should be covered'
     })
     .option('check-coverage', {
       default: false,

--- a/lib/report.js
+++ b/lib/report.js
@@ -28,7 +28,8 @@ class Report {
     src,
     allowExternal = false,
     skipFull,
-    excludeNodeModules
+    excludeNodeModules,
+    extension
   }) {
     this.reporter = reporter
     this.reportsDirectory = reportsDirectory
@@ -39,7 +40,8 @@ class Report {
       exclude: exclude,
       include: include,
       relativePath: !allowExternal,
-      excludeNodeModules: excludeNodeModules
+      excludeNodeModules: excludeNodeModules,
+      extension: extension
     })
     this.excludeAfterRemap = excludeAfterRemap
     this.omitRelative = omitRelative
@@ -187,12 +189,13 @@ class Report {
         result: emptyReports
       })
       const workingDirs = this.src
+      const { extension } = this.exclude
       for (const workingDir of workingDirs) {
         this.exclude.globSync(workingDir).forEach((f) => {
           const fullPath = resolve(workingDir, f)
           if (!fileIndex.has(fullPath)) {
             const ext = extname(fullPath)
-            if (ext === '.js' || ext === '.ts' || ext === '.mjs') {
+            if (extension.includes(ext)) {
               const stat = statSync(fullPath)
               const sourceMap = getSourceMapFromFile(fullPath)
               if (sourceMap) {


### PR DESCRIPTION
Adding `--extension` option, allowing override of defaults. 

I'm using experimental ESM loaders to have Node.js process `.svelte` files, and now I can run code coverage on them too.

Modified `--all` option to check file extensions against `extension` list
instead of a hard-coded list.

Updated links for default lists in README for `--exclude` and `--extension`.

Tests are passing.

I did not add new tests, as that would require either changing, or adding, a
test runner to use ESM loaders. As the changes here are simple, I thought it
might be overkill. But let me know what you think.

thanks!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
