### PR TITLE
feature: report: ability to use dynamic source maps for `?count=x` imported files

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -93,7 +93,7 @@ class Report {
     for (const v8ScriptCov of v8ProcessCov.result) {
       try {
         const sources = this._getSourceMap(v8ScriptCov)
-        const path = resolve(this.resolve, v8ScriptCov.url)
+        const path = resolve(this.resolve, fileURLToPath(v8ScriptCov.url))
         const converter = v8toIstanbul(path, this.wrapperLength, sources, (path) => {
           if (this.excludeAfterRemap) {
             return !this.exclude.shouldInstrument(path)
@@ -143,7 +143,7 @@ class Report {
    */
   _getSourceMap (v8ScriptCov) {
     const sources = {}
-    const sourceMapAndLineLengths = this.sourceMapCache[pathToFileURL(v8ScriptCov.url).href]
+    const sourceMapAndLineLengths = this.sourceMapCache[v8ScriptCov.url]
     if (sourceMapAndLineLengths) {
       // See: https://github.com/nodejs/node/pull/34305
       if (!sourceMapAndLineLengths.data) return
@@ -279,15 +279,15 @@ class Report {
       }
       if (/^file:\/\//.test(v8ScriptCov.url)) {
         try {
-          v8ScriptCov.url = fileURLToPath(v8ScriptCov.url)
           fileIndex.add(v8ScriptCov.url)
         } catch (err) {
           debuglog(`${err.stack}`)
           continue
         }
       }
-      if ((!this.omitRelative || isAbsolute(v8ScriptCov.url))) {
-        if (this.excludeAfterRemap || this.exclude.shouldInstrument(v8ScriptCov.url)) {
+
+      if ((!this.omitRelative || /^file:\/\//.test(v8ScriptCov.url))) {
+        if (this.excludeAfterRemap || this.exclude.shouldInstrument(fileURLToPath(v8ScriptCov.url))) {
           result.push(v8ScriptCov)
         }
       }
@@ -307,7 +307,7 @@ class Report {
   _normalizeSourceMapCache (v8SourceMapCache) {
     const cache = {}
     for (const fileURL of Object.keys(v8SourceMapCache)) {
-      cache[pathToFileURL(fileURLToPath(fileURL)).href] = v8SourceMapCache[fileURL]
+      cache[fileURL] = v8SourceMapCache[fileURL];
     }
     return cache
   }


### PR DESCRIPTION
This is example of changes that can be made to get support of loaded and transformed files (#325).

As I understand, the problem can be somewhere in [v8-to-instanbul](https://github.com/istanbuljs/v8-to-istanbul/blob/v8.1.0/lib/v8-to-istanbul.js#L108-L185) when we are going to apply coverage. The thing is files sizes is different, and offsets different too, and they should be converted somehow 🤔. And there is conversion but it returns `Infinity` and `NaN` for some reason. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `npm test`, tests passing
- [ ] `npm run test:snap` (to update the snapshot)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
