### PR TITLE
fix(ts-node): Disable tsconfig.json loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/node": "^16.9.1",
         "chai": "^4.2.0",
         "chai-jest-snapshot": "^2.0.0",
+        "cross-env": "^7.0.3",
         "mocha": "^9.0.0",
         "standard": "^16.0.3",
         "ts-node": "^10.0.0",
@@ -603,6 +604,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -4502,6 +4521,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "git@github.com:bcoe/c8.git"
   },
   "scripts": {
-    "test": "node ./bin/c8.js mocha --timeout=8000 ./test/*.js",
-    "coverage": "node ./bin/c8.js --check-coverage mocha --timeout=8000 ./test/*.js",
+    "test": "cross-env TS_NODE_SKIP_PROJECT=true node ./bin/c8.js mocha --timeout=8000 ./test/*.js",
+    "coverage": "cross-env TS_NODE_SKIP_PROJECT=true node ./bin/c8.js --check-coverage mocha --timeout=8000 ./test/*.js",
     "test:snap": "CHAI_JEST_SNAPSHOT_UPDATE_ALL=true npm test",
     "fix": "standard --fix",
     "posttest": "standard"
@@ -50,6 +50,7 @@
     "@types/node": "^16.9.1",
     "chai": "^4.2.0",
     "chai-jest-snapshot": "^2.0.0",
+    "cross-env": "^7.0.3",
     "mocha": "^9.0.0",
     "standard": "^16.0.3",
     "ts-node": "^10.0.0",


### PR DESCRIPTION
Currently there is no custom `tsconfig.json` to be used by `ts-node` inside this project. There is no reason to let `ts-node` resolve a configuration present outside this project on the filesystem. Fixes #348.

##### Checklist
- [x] `npm test`, tests passing
