### PR TITLE
chore: regenerate test/integration.js.snap

### DIFF
--- a/test/integration.js.snap
+++ b/test/integration.js.snap
@@ -157,43 +157,6 @@ All files   |   83.33 |      100 |   66.66 |   83.33 |
 ,"
 `;
 
-exports[`c8 can allow for files outside of cwd 1`] = `
-",hi
--------------------|---------|----------|---------|---------|-------------------
-File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------|---------|----------|---------|---------|-------------------
-All files          |     100 |      100 |     100 |     100 |                   
- multidir1         |     100 |      100 |     100 |     100 |                   
-  file1.js         |     100 |      100 |     100 |     100 |                   
- report            |     100 |      100 |     100 |     100 |                   
-  allowExternal.js |     100 |      100 |     100 |     100 |                   
--------------------|---------|----------|---------|---------|-------------------
-,"
-`;
-
-exports[`c8 check-coverage --100  1`] = `
-",hey
-i am a line of code
-what
-hey
-what
-hey
-what
-hey
------------|---------|----------|---------|---------|-------------------
-File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------|---------|----------|---------|---------|-------------------
-All files  |   83.33 |    85.71 |      60 |   83.33 |                   
- async.js  |     100 |      100 |     100 |     100 |                   
- normal.js |      75 |    66.66 |   33.33 |      75 | 14-16,18-20       
------------|---------|----------|---------|---------|-------------------
-,ERROR: Coverage for lines (83.33%) does not meet global threshold (100%)
-ERROR: Coverage for functions (60%) does not meet global threshold (100%)
-ERROR: Coverage for branches (85.71%) does not meet global threshold (100%)
-ERROR: Coverage for statements (83.33%) does not meet global threshold (95%)
-"
-`;
-
 exports[`c8 check-coverage --100 1`] = `
 ",hey
 i am a line of code
@@ -243,14 +206,6 @@ exports[`c8 check-coverage allows threshold to be applied on per-file basis 1`] 
 ERROR: Coverage for lines (75%) does not meet threshold (101%) for test/fixtures/normal.js
 ERROR: Coverage for branches (66.66%) does not meet threshold (82%) for test/fixtures/normal.js
 ERROR: Coverage for statements (75%) does not meet threshold (95%) for test/fixtures/normal.js
-"
-`;
-
-exports[`c8 check-coverage check-coverage --100 1`] = `
-",,ERROR: Coverage for lines (83.33%) does not meet global threshold (100%)
-ERROR: Coverage for functions (60%) does not meet global threshold (100%)
-ERROR: Coverage for branches (85.71%) does not meet global threshold (100%)
-ERROR: Coverage for statements (83.33%) does not meet global threshold (95%)
 "
 `;
 
@@ -603,20 +558,5 @@ All files  |   83.33 |    85.71 |      60 |   83.33 |
  async.js  |     100 |      100 |     100 |     100 |                   
  normal.js |      75 |    66.66 |   33.33 |      75 | 14-16,18-20       
 -----------|---------|----------|---------|---------|-------------------
-,"
-`;
-
-exports[`c8 ts-node reads source-map from cache, and applies to coverage 1`] = `
-",covered
-covered
-covered
-covered
-covered
-------------------|---------|----------|---------|---------|-------------------
-File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
-All files         |   88.24 |     87.5 |      80 |   88.24 |                   
- ts-node-basic.ts |   88.24 |     87.5 |      80 |   88.24 | 12-13,28-29       
-------------------|---------|----------|---------|---------|-------------------
 ,"
 `;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)

I suspect this is due to a bug in chai-jest-snapshot.