### PR TITLE
feat: use process.stdout.columns for reporter maxCols

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -74,7 +74,7 @@ class Report {
       reports.create(_reporter, {
         skipEmpty: false,
         skipFull: this.skipFull,
-        maxCols: 100
+        maxCols: process.stdout.columns || 100
       }).execute(context)
     }
   }


### PR DESCRIPTION
Hi,

this PR is changing the default `maxCols` width from `100` to whatever is the current terminal, using `process.stdout.columns`. If that's not available for any reason(ci?) it fallbacks to 100.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)
