### PR TITLE
docs: change 'master' to 'main' in git commands and links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ the requirements below.
 
 Bug fixes and new features should include tests and possibly benchmarks.
 
-Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
+Contributors guide: https://github.com/bcoe/c8/blob/main/CONTRIBUTING.md
 -->
 
 ##### Checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,10 @@ Pull Requests are the way concrete changes are made to the code, documentation, 
     git fetch upstream
     ```
 
-1. Create local branches to work within. These should also be created directly off of the master branch:
+1. Create local branches to work within. These should also be created directly off of the main branch:
 
     ```sh
-    git checkout -b my-branch -t upstream/master
+    git checkout -b my-branch -t upstream/main
     ```
 
 1. Make your changes
@@ -47,7 +47,7 @@ Pull Requests are the way concrete changes are made to the code, documentation, 
 
     ```sh
     git fetch upstream
-    git rebase upstream/master
+    git rebase upstream/main
     ```
 
 1. Run tests again to make sure all is okay


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/master/CONTRIBUTING.md
-->
Rename the c8 repo 'master' branch to 'main' in git commands and in a link in the PR template.
I stumbled on the outdated git commands while working on another PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] documentation is changed or added
