### PR TITLE
feat: support passing reporter options

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -19,6 +19,7 @@ class Report {
     excludeAfterRemap,
     include,
     reporter,
+    reporterOptions,
     reportsDirectory,
     tempDirectory,
     watermarks,
@@ -32,6 +33,7 @@ class Report {
     excludeNodeModules
   }) {
     this.reporter = reporter
+    this.reporterOptions = reporterOptions || {}
     this.reportsDirectory = reportsDirectory
     this.tempDirectory = tempDirectory
     this.watermarks = watermarks
@@ -74,7 +76,8 @@ class Report {
       reports.create(_reporter, {
         skipEmpty: false,
         skipFull: this.skipFull,
-        maxCols: process.stdout.columns || 100
+        maxCols: process.stdout.columns || 100,
+        ...this.reporterOptions[_reporter]
       }).execute(context)
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2381,9 +2381,9 @@
       "dev": true
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5798,9 +5798,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/test/integration.js.snap
+++ b/test/integration.js.snap
@@ -168,7 +168,7 @@ All files                              |    1.91 |       12 |    6.25 |    1.91 
  c8/lib                                |       0 |        0 |       0 |       0 |                   
   is-cjs-esm-bridge.js                 |       0 |        0 |       0 |       0 | 1-10              
   parse-args.js                        |       0 |        0 |       0 |       0 | 1-218             
-  report.js                            |       0 |        0 |       0 |       0 | 1-337             
+  report.js                            |       0 |        0 |       0 |       0 | 1-340             
   source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100             
  c8/lib/commands                       |       0 |        0 |       0 |       0 |                   
   check-coverage.js                    |       0 |        0 |       0 |       0 | 1-70              

--- a/test/integration.js_10.snap
+++ b/test/integration.js_10.snap
@@ -168,7 +168,7 @@ All files                              |    1.91 |       12 |    8.16 |    1.91 
  c8/lib                                |       0 |        0 |       0 |       0 |                   
   is-cjs-esm-bridge.js                 |       0 |        0 |       0 |       0 | 1-10              
   parse-args.js                        |       0 |        0 |       0 |       0 | 1-218             
-  report.js                            |       0 |        0 |       0 |       0 | 1-337             
+  report.js                            |       0 |        0 |       0 |       0 | 1-340             
   source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100             
  c8/lib/commands                       |       0 |        0 |       0 |       0 |                   
   check-coverage.js                    |       0 |        0 |       0 |       0 | 1-70              
@@ -257,13 +257,13 @@ hey
 --------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |   73.95 |    58.82 |   63.41 |   73.95 |                                
+All files                 |   74.04 |    58.82 |   63.41 |   74.04 |                                
  bin                      |   78.84 |       60 |   66.66 |   78.84 |                                
   c8.js                   |   78.84 |       60 |   66.66 |   78.84 | 22,27-29,32-33,41-43,50-51     
- lib                      |   78.49 |    54.23 |   73.07 |   78.49 |                                
+ lib                      |   78.59 |    54.23 |   73.07 |   78.59 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
   parse-args.js           |   97.24 |    58.33 |     100 |   97.24 | 159-160,181-182,195-196        
-  report.js               |   75.96 |    57.89 |      80 |   75.96 | ...281,287-289,310-315,326-327 
+  report.js               |   76.17 |    57.89 |      80 |   76.17 | ...284,290-292,313-318,329-330 
   source-map-from-file.js |      45 |      100 |       0 |      45 | 39-50,52-67,69-77,81-98        
  lib/commands             |   41.44 |    66.66 |   16.66 |   41.44 |                                
   check-coverage.js       |   18.57 |      100 |       0 |   18.57 | 9-11,14-36,39-53,55-70         
@@ -272,9 +272,9 @@ All files                 |   73.95 |    58.82 |   63.41 |   73.95 |
   async.js                |     100 |      100 |     100 |     100 |                                
   normal.js               |      75 |    66.66 |   33.33 |      75 | 14-16,18-20                    
 --------------------------|---------|----------|---------|---------|--------------------------------
-,ERROR: Coverage for lines (73.95%) does not meet global threshold (101%)
+,ERROR: Coverage for lines (74.04%) does not meet global threshold (101%)
 ERROR: Coverage for branches (58.82%) does not meet global threshold (82%)
-ERROR: Coverage for statements (73.95%) does not meet global threshold (95%)
+ERROR: Coverage for statements (74.04%) does not meet global threshold (95%)
 "
 `;
 
@@ -292,9 +292,9 @@ ERROR: Coverage for branches (25%) does not meet threshold (82%) for lib/is-cjs-
 ERROR: Coverage for statements (90%) does not meet threshold (95%) for lib/is-cjs-esm-bridge.js
 ERROR: Coverage for lines (97.24%) does not meet threshold (101%) for lib/parse-args.js
 ERROR: Coverage for branches (58.33%) does not meet threshold (82%) for lib/parse-args.js
-ERROR: Coverage for lines (75.96%) does not meet threshold (101%) for lib/report.js
+ERROR: Coverage for lines (76.17%) does not meet threshold (101%) for lib/report.js
 ERROR: Coverage for branches (57.89%) does not meet threshold (82%) for lib/report.js
-ERROR: Coverage for statements (75.96%) does not meet threshold (95%) for lib/report.js
+ERROR: Coverage for statements (76.17%) does not meet threshold (95%) for lib/report.js
 ERROR: Coverage for lines (45%) does not meet threshold (101%) for lib/source-map-from-file.js
 ERROR: Coverage for statements (45%) does not meet threshold (95%) for lib/source-map-from-file.js
 ERROR: Coverage for lines (100%) does not meet threshold (101%) for test/fixtures/async.js
@@ -305,19 +305,19 @@ ERROR: Coverage for statements (75%) does not meet threshold (95%) for test/fixt
 `;
 
 exports[`c8 check-coverage check-coverage command with --100 1`] = `
-",,ERROR: Coverage for lines (77.66%) does not meet global threshold (100%)
+",,ERROR: Coverage for lines (77.73%) does not meet global threshold (100%)
 ERROR: Coverage for functions (67.44%) does not meet global threshold (100%)
 ERROR: Coverage for branches (62.06%) does not meet global threshold (100%)
-ERROR: Coverage for statements (77.66%) does not meet global threshold (100%)
+ERROR: Coverage for statements (77.73%) does not meet global threshold (100%)
 "
 `;
 
 exports[`c8 check-coverage exits with 0 if coverage within threshold 1`] = `",,"`;
 
 exports[`c8 check-coverage exits with 1 if coverage is below threshold 1`] = `
-",,ERROR: Coverage for lines (73.95%) does not meet global threshold (101%)
+",,ERROR: Coverage for lines (74.04%) does not meet global threshold (101%)
 ERROR: Coverage for branches (58.82%) does not meet global threshold (82%)
-ERROR: Coverage for statements (73.95%) does not meet global threshold (95%)
+ERROR: Coverage for statements (74.04%) does not meet global threshold (95%)
 "
 `;
 
@@ -404,13 +404,13 @@ exports[`c8 report generates report from existing temporary files 1`] = `
 ",--------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |   73.95 |    58.82 |   63.41 |   73.95 |                                
+All files                 |   74.04 |    58.82 |   63.41 |   74.04 |                                
  bin                      |   78.84 |       60 |   66.66 |   78.84 |                                
   c8.js                   |   78.84 |       60 |   66.66 |   78.84 | 22,27-29,32-33,41-43,50-51     
- lib                      |   78.49 |    54.23 |   73.07 |   78.49 |                                
+ lib                      |   78.59 |    54.23 |   73.07 |   78.59 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
   parse-args.js           |   97.24 |    58.33 |     100 |   97.24 | 159-160,181-182,195-196        
-  report.js               |   75.96 |    57.89 |      80 |   75.96 | ...281,287-289,310-315,326-327 
+  report.js               |   76.17 |    57.89 |      80 |   76.17 | ...284,290-292,313-318,329-330 
   source-map-from-file.js |      45 |      100 |       0 |      45 | 39-50,52-67,69-77,81-98        
  lib/commands             |   41.44 |    66.66 |   16.66 |   41.44 |                                
   check-coverage.js       |   18.57 |      100 |       0 |   18.57 | 9-11,14-36,39-53,55-70         
@@ -426,13 +426,13 @@ exports[`c8 report supports --check-coverage, when generating reports 1`] = `
 ",--------------------------|---------|----------|---------|---------|--------------------------------
 File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s              
 --------------------------|---------|----------|---------|---------|--------------------------------
-All files                 |   73.95 |    58.82 |   63.41 |   73.95 |                                
+All files                 |   74.04 |    58.82 |   63.41 |   74.04 |                                
  bin                      |   78.84 |       60 |   66.66 |   78.84 |                                
   c8.js                   |   78.84 |       60 |   66.66 |   78.84 | 22,27-29,32-33,41-43,50-51     
- lib                      |   78.49 |    54.23 |   73.07 |   78.49 |                                
+ lib                      |   78.59 |    54.23 |   73.07 |   78.59 |                                
   is-cjs-esm-bridge.js    |      90 |       25 |     100 |      90 | 9                              
   parse-args.js           |   97.24 |    58.33 |     100 |   97.24 | 159-160,181-182,195-196        
-  report.js               |   75.96 |    57.89 |      80 |   75.96 | ...281,287-289,310-315,326-327 
+  report.js               |   76.17 |    57.89 |      80 |   76.17 | ...284,290-292,313-318,329-330 
   source-map-from-file.js |      45 |      100 |       0 |      45 | 39-50,52-67,69-77,81-98        
  lib/commands             |   41.44 |    66.66 |   16.66 |   41.44 |                                
   check-coverage.js       |   18.57 |      100 |       0 |   18.57 | 9-11,14-36,39-53,55-70         
@@ -441,9 +441,9 @@ All files                 |   73.95 |    58.82 |   63.41 |   73.95 |
   async.js                |     100 |      100 |     100 |     100 |                                
   normal.js               |      75 |    66.66 |   33.33 |      75 | 14-16,18-20                    
 --------------------------|---------|----------|---------|---------|--------------------------------
-,ERROR: Coverage for lines (73.95%) does not meet global threshold (101%)
+,ERROR: Coverage for lines (74.04%) does not meet global threshold (101%)
 ERROR: Coverage for branches (58.82%) does not meet global threshold (82%)
-ERROR: Coverage for statements (73.95%) does not meet global threshold (95%)
+ERROR: Coverage for statements (74.04%) does not meet global threshold (95%)
 "
 `;
 


### PR DESCRIPTION
For example:

```
{
  reporter: ['text'],
  reporterOptions: {
    text: { file: 'coverage.txt' },
  }
}
```

This enables overriding the `file` option which normally defaults to `null`, so text reporters can write to a file rather than stdout: https://github.com/istanbuljs/istanbuljs/blob/fb8cb4bb99c9e5d36c8b011338d2ab5d3c72ff9c/packages/istanbul-reports/lib/text/index.js#L233-L237

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
