### PR TITLE
docs: add `--per-file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Here is a list of common options. Run `c8 --help` for the full list and document
 | `-e`, `--extension` | only files matching these extensions will show coverage | `string \| Array<string>` | [list](https://github.com/istanbuljs/schema/blob/master/default-extension.js) |
 | `--skip-full` | do not show files with 100% statement, branch, and function coverage | `boolean` | `false` |
 | `--check-coverage` | check whether coverage is within thresholds provided | `boolean` | `false` |
+| `--per-file` | check thresholds per file | `boolean` | `false` |
 | `--temp-directory` | directory V8 coverage data is written to and read from | `string` | `process.env.NODE_V8_COVERAGE` |
 | `--clean` | should temp files be deleted before script execution | `boolean` | `true` |
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/main/CONTRIBUTING.md
-->

While rewriting `vitest`'s coverage configuration documentation I noticed the `per-file` option is not included in `c8`'s documentation. It is implemented though:

https://github.com/bcoe/c8/blob/bc347a91f06a3fea7b7425c4affd66d7f8b9d416/lib/commands/check-coverage.js#L46-L52

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is changed or added
