### PR TITLE
Increase Code Quality By Increasing Code Coverage: lib/parse-args.js

### DIFF
--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -30,7 +30,8 @@ function buildYargs (withCommands = false) {
       alias: ['o', 'report-dir'],
       group: 'Reporting options',
       describe: 'directory where coverage reports will be output to',
-      default: './coverage'
+      default: './coverage',
+      type: 'string'
     })
     .options('all', {
       default: false,
@@ -126,7 +127,8 @@ function buildYargs (withCommands = false) {
     })
     .option('temp-directory', {
       describe: 'directory V8 coverage data is written to and read from',
-      default: process.env.NODE_V8_COVERAGE
+      default: process.env.NODE_V8_COVERAGE,
+      type: 'string'
     })
     .option('clean', {
       default: true,
@@ -207,12 +209,12 @@ function hideInstrumenteeArgs () {
   let argv = process.argv.slice(2)
   const yargv = parser(argv)
 
-  if (!yargv._.length) return argv
-
-  // drop all the arguments after the bin being
-  // instrumented by c8.
-  argv = argv.slice(0, argv.indexOf(yargv._[0]))
-  argv.push(yargv._[0])
+  if (yargv._.length !== 0) {
+    // drop all the arguments after the bin being
+    // instrumented by c8.
+    argv = argv.slice(0, argv.indexOf(yargv._[0]))
+    argv.push(yargv._[0])
+  }
 
   return argv
 }

--- a/test/integration.js.snap
+++ b/test/integration.js.snap
@@ -166,7 +166,7 @@ All files                              |    3.52 |     12.5 |    6.52 |    3.52 
   prettify.js                          |       0 |        0 |       0 |       0 | 1-2                    
   sorter.js                            |       0 |        0 |       0 |       0 | 1-196                  
  c8/lib                                |       0 |        0 |       0 |       0 |                        
-  parse-args.js                        |       0 |        0 |       0 |       0 | 1-224                  
+  parse-args.js                        |       0 |        0 |       0 |       0 | 1-226                  
   report.js                            |       0 |        0 |       0 |       0 | 1-402                  
   source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100                  
  c8/lib/commands                       |       0 |        0 |       0 |       0 |                        
@@ -531,7 +531,7 @@ All files                              |    3.52 |     12.5 |    6.52 |    3.52 
   prettify.js                          |       0 |        0 |       0 |       0 | 1-2                    
   sorter.js                            |       0 |        0 |       0 |       0 | 1-196                  
  c8/lib                                |       0 |        0 |       0 |       0 |                        
-  parse-args.js                        |       0 |        0 |       0 |       0 | 1-224                  
+  parse-args.js                        |       0 |        0 |       0 |       0 | 1-226                  
   report.js                            |       0 |        0 |       0 |       0 | 1-402                  
   source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100                  
  c8/lib/commands                       |       0 |        0 |       0 |       0 |                        


### PR DESCRIPTION
# **[Pull Request 447](https://github.com/bcoe/c8/pull/447)**

Increase code quality by increasing code coverage: lib/parse-args.js

refactor: bumping code coverage to 100% for lib/parse-args.js. (#447)
test: Adding a test case for NODE_V8_COVERAGE and changing the describe block title. (#447)
test: Early exit branch test for hideInstrumenteeArgs function. (#447)
test: Adding test for relative paths for relative report directory cli option. (#447)
test: Adding test case for relative paths for temporary directory cli option. (#447)
test: Adding test for passing node.js arguments to c8. (#447)

## **Following the Contributions Recommendations [here.](https://github.com/bcoe/c8/blob/main/CONTRIBUTING.md)**

1. [x] Make sure you have installed the latest version of Node.js
2. [x] Fork this project on GitHub and clone your fork locally
3. [x] Create local branches to work within. These should also be created directly from the main branch.  Local Fork [here.](https://github.com/mcknasty/c8)
4. [x] Make your changes.
5. [x] Run tests to make sure all is okay (everything should pass except the snapshot).
   1. A [complete log](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-initial-test-txt) of initial test results.
   2. As instructed, ignore snapshot failures. 0 failures
   3. [100 passing](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-initial-test-txt-L151) in [48 seconds](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-initial-test-txt-L151)
6. [x] Now update the snapshot.
   1. A [complete log](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-snapshot-test-txt) of snapshot test results.
   2. [100 passing](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-snapshot-test-txt-L155) in [48 seconds](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-snapshot-test-txt-L155)
7. [x] If all is passing, commit your changes. The log of the commit can be found [here.](https://github.com/bcoe/c8/pull/447/commits/7e611964a10968425f643a45124db1b0beabd4f5)
8. [x] As a best practice, once you have committed your changes, it is a good idea to use git rebase (not git merge) to synchronize your work with the main repository.
9. [x] Run tests again to make sure all is okay.
    1. A [complete log](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-final-test-txt) of the final test results.
    2. [100 passing](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-final-test-txt-L151) in [48 seconds](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-final-test-txt-L151)
10. [x] Push
11. [x] Open the pull request, see details in the template.
12. [ ] Make any necessary changes after review.

## **File Code Coverage Matrix Report**

|   Test Type   | File    | Statement | Branch | Function | Lines |
|---------------|---------|-----------|--------|----------|-------|
| Final Test | [lib/parse-args.js](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-final-test-txt-L160) | 100% | 100% | 100% | 100% |
| Node 14.21.3 | [lib/parse-args.js](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v14-21-3-test-txt-L183) | 100% | 100% | 100% | 100% |
| Node 16.20.2 | [lib/parse-args.js](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v16-20-2-test-txt-L184) | 100% | 100% | 100% | 100% |
| Node 18.19.0 | [lib/parse-args.js](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v18-19-0-test-txt-L180) | 100% | 100% | 100% | 100% |
| Node 20.11.0 | [lib/parse-args.js](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v20-11-0-test-txt-L180) | 100% | 100% | 100% | 100% |

## **Unit Tests Results**

All tests run on Node version 18.19.0

|   Test Type     |  PASS          |  Tests Passed   |  Tests Failed  |    Time      |
|:---------------:|:--------------:|:---------------:|:--------------:|:------------:|
| [Initial Test](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-initial-test-txt)       | :heavy_check_mark: | [100 passing](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-initial-test-txt-L151)        | 0 failures       | [48 seconds](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-initial-test-txt-L151)       |
| [Snapshot Test](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-snapshot-test-txt)       | :heavy_check_mark: | [100 passing](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-snapshot-test-txt-L155)        | 0 failures       | [48 seconds](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-snapshot-test-txt-L155)       |
| [Final Test](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-final-test-txt)       | :heavy_check_mark: | [100 passing](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-final-test-txt-L151)        | 0 failures       | [48 seconds](https://gist.github.com/mcknasty/9cb0f0ed7c6c63210fd6f345e4796166#file-final-test-txt-L151)       |

## **Node Version Testing Matrix**

|   Node Version  |  PASS          |  Tests Passed   |  Tests Failed  |    Time      |
|:---------------:|:--------------:|:---------------:|:--------------:|:------------:|
| [14.21.3](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v14-21-3-test-txt)       | :heavy_check_mark: | [100 passing](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v14-21-3-test-txt-L174)        | 0 failures       | [55 seconds](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v14-21-3-test-txt-L174)       |
| [16.20.2](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v16-20-2-test-txt)       | :heavy_check_mark: | [100 passing](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v16-20-2-test-txt-L175)        | 0 failures       | [1 minutes](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v16-20-2-test-txt-L175)       |
| [18.19.0](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v18-19-0-test-txt)       | :heavy_check_mark: | [100 passing](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v18-19-0-test-txt-L171)        | 0 failures       | [55 seconds](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v18-19-0-test-txt-L171)       |
| [20.11.0](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v20-11-0-test-txt)       | :heavy_check_mark: | [100 passing](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v20-11-0-test-txt-L171)        | 0 failures       | [1 minutes](https://gist.github.com/mcknasty/858aa5d8ea51fba08ef0d2062632180d#file-v20-11-0-test-txt-L171)       |

Referencing Issue #448

Updated 2023-07-29 7:59 PM EST
Updated 2023-07-30 11:25 AM EST
Updated 2024-01-14 9:03 PM EST
