### PR TITLE
feat: support passing reporter options from config

### DIFF
--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -25,6 +25,7 @@ exports.outputReport = async function (argv) {
     excludeAfterRemap: argv.excludeAfterRemap,
     reporter: Array.isArray(argv.reporter) ? argv.reporter : [argv.reporter],
     reportsDirectory: argv['reports-dir'],
+    reporterOptions: argv.reporterOptions || {},
     tempDirectory: argv.tempDirectory,
     watermarks: argv.watermarks,
     resolve: argv.resolve,

--- a/test/integration.js.snap
+++ b/test/integration.js.snap
@@ -171,7 +171,7 @@ All files                              |    3.52 |     12.5 |    6.52 |    3.52 
   source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100                  
  c8/lib/commands                       |       0 |        0 |       0 |       0 |                        
   check-coverage.js                    |       0 |        0 |       0 |       0 | 1-70                   
-  report.js                            |       0 |        0 |       0 |       0 | 1-42                   
+  report.js                            |       0 |        0 |       0 |       0 | 1-43                   
  c8/test/fixtures                      |   30.97 |     37.5 |   21.42 |   30.97 |                        
   async.js                             |     100 |      100 |     100 |     100 |                        
   c8-ignore-next.js                    |   54.54 |        0 |       0 |   54.54 | 1,3-4,9,12,17-19,21-22 
@@ -536,7 +536,7 @@ All files                              |    3.52 |     12.5 |    6.52 |    3.52 
   source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100                  
  c8/lib/commands                       |       0 |        0 |       0 |       0 |                        
   check-coverage.js                    |       0 |        0 |       0 |       0 | 1-70                   
-  report.js                            |       0 |        0 |       0 |       0 | 1-42                   
+  report.js                            |       0 |        0 |       0 |       0 | 1-43                   
  c8/test/fixtures                      |   30.97 |     37.5 |   21.42 |   30.97 |                        
   async.js                             |     100 |      100 |     100 |     100 |                        
   c8-ignore-next.js                    |   54.54 |        0 |       0 |   54.54 | 1,3-4,9,12,17-19,21-22 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/main/CONTRIBUTING.md
-->

I saw that the reporter allowed passing reporter options – since #423.
This PR originally also include a use case: c8 config.
```json5
{
  reporter: ['text'],
  reporterOptions: {
    text: { file: 'coverage.txt' },
  }
}
```

Here is another real world use case: 
```json
{
  "all": true,
  "reporter": ["text-summary", "clover", "html"],
  "reporterOptions": {
    "clover": {"file": "coverage.clover.xml"},
    "html": {"subdir": "coverage.html"}
  },
  "reports-dir": "./reports",
  "temp-directory": "./.c8.cache"
}

```

Unfortunately, the original feature forgot to implement the solution to the exact use case.
SO the actual feature was never accessible/working/existing.

Here is the solution: `reporterOptions` from the config are passed to reporters.

I do not have any idea how the CLI could look like to configure this. So I did not implement it and also did not update any docs.
CLI might be like `c8 --reporter-option clover.file=coverage.clover.xml --reporter-option html.subdir=coverage.html`. Or something else. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
