### PR TITLE
test: additional tests for relative path support

### DIFF
--- a/test/parse-args.js
+++ b/test/parse-args.js
@@ -6,7 +6,7 @@ const {
   hideInstrumenterArgs
 } = require('../lib/parse-args')
 
-const { join } = require('path')
+const { join, resolve } = require('path')
 
 describe('parse-args', () => {
   describe('hideInstrumenteeArgs', () => {
@@ -62,6 +62,28 @@ describe('parse-args', () => {
       argv.branches.should.be.equal(55)
       argv.lines.should.be.equal(100)
       argv.functions.should.be.equal(24)
+    })
+    it('should allow relative path reports directories', () => {
+      const argsArray = ['node', 'c8', '--lines', '100', '--reports-dir', './coverage_']
+      const argv = buildYargs().parse(argsArray)
+      argv.reportsDir.should.be.equal('./coverage_')
+    })
+    it('should allow relative path temporary directories', () => {
+      const argsArray = ['node', 'c8', '--lines', '100', '--temp-directory', './coverage/tmp_']
+      const argv = buildYargs().parse(argsArray)
+      argv.tempDirectory.should.be.equal('./coverage/tmp_')
+    })
+    it('should allow absolute path reports directories', () => {
+      const tmpDir = resolve(process.cwd(), 'coverage_')
+      const argsArray = ['node', 'c8', '--lines', '100', '--reports-dir', tmpDir]
+      const argv = buildYargs().parse(argsArray)
+      argv.reportsDir.should.be.equal(tmpDir)
+    })
+    it('should allow absolute path temporary directories', () => {
+      const tmpDir = resolve(process.cwd(), './coverage/tmp_')
+      const argsArray = ['node', 'c8', '--lines', '100', '--temp-directory', tmpDir]
+      const argv = buildYargs().parse(argsArray)
+      argv.tempDirectory.should.be.equal(tmpDir)
     })
   })
 


### PR DESCRIPTION
# **[Pull Request 490](https://github.com/bcoe/c8/pull/490)**

Artifact Directory Unit Tests

test: relative directories for tmpDir and reportsDir
test: absolute directories for tmpDir and reportsDir

## **Following the Contributions Recommendations [here.](https://github.com/bcoe/c8/blob/main/CONTRIBUTING.md)**

1. [x] Make sure you have installed the latest version of Node.js
2. [x] Fork this project on GitHub and clone your fork locally
3. [x] Create local branches to work within. These should also be created directly from the main branch.  Local Fork [here.](https://github.com/mcknasty/c8)
4. [x] Make your changes.
5. [x] Run tests to make sure all is okay (everything should pass except the snapshot).
   1. A [complete log](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-initial-test-txt) of initial test results.
   2. As instructed, ignore snapshot failures. [2 failing](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-initial-test-txt-L151)
   3. [97 passing](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-initial-test-txt-L150) in [50 seconds](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-initial-test-txt-L150)
6. [x] Now update the snapshot.
   1. A [complete log](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-snapshot-test-txt) of snapshot test results.
   2. [99 passing](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-snapshot-test-txt-L154) in [46 seconds](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-snapshot-test-txt-L154)
7. [x] If all is passing, commit your changes. The log of the commit can be found [here.](https://github.com/bcoe/c8/pull/490/commits/5ed96e5da5f6da5f51730c0bb8593b634fde587b)
8. [x] As a best practice, once you have committed your changes, it is a good idea to use git rebase (not git merge) to synchronize your work with the main repository.
9. [x] Run tests again to make sure all is okay.
    1. A [complete log](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-final-test-txt) of the final test results.
    2. [99 passing](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-final-test-txt-L150) in [50 seconds](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-final-test-txt-L150)
10. [x] Push
11. [x] Open the pull request, see details in the template.
12. [ ] Make any necessary changes after review.

## **Unit Tests Results**

|   Test Type     |  PASS          |  Tests Passed   |  Tests Failed  |    Time      |
|:---------------:|:--------------:|:---------------:|:--------------:|:------------:|
| [Initial Test](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-initial-test-txt)       | :x: | [97 passing](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-initial-test-txt-L150)        | [2 failing](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-initial-test-txt-L151)       | [50 seconds](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-initial-test-txt-L150)       |
| [Snapshot Test](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-snapshot-test-txt)       | :heavy_check_mark: | [99 passing](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-snapshot-test-txt-L154)        | 0 failures       | [46 seconds](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-snapshot-test-txt-L154)       |
| [Final Test](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-final-test-txt)       | :heavy_check_mark: | [99 passing](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-final-test-txt-L150)        | 0 failures       | [50 seconds](https://gist.github.com/mcknasty/313be9529ebaa41cba7be7e94b8aee09#file-final-test-txt-L150)       |

## **Node Version Testing Matrix**

|   Node Version  |  PASS          |  Tests Passed   |  Tests Failed  |    Time      |
|:---------------:|:--------------:|:---------------:|:--------------:|:------------:|
| [10.24.1](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v10-24-1-tests-txt)*  | :x: | :x: | :x: |:x: |
| [12.22.12](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v12-22-12-tests-txt)       | :heavy_check_mark: | [99 passing](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v12-22-12-tests-txt-L173)        | 0 failures       | [1 minutes](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v12-22-12-tests-txt-L173)       |
| [14.21.3](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v14-21-3-tests-txt)       | :heavy_check_mark: | [99 passing](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v14-21-3-tests-txt-L169)        | 0 failures       | [1 minutes](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v14-21-3-tests-txt-L169)       |
| [16.20.1](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v16-20-1-tests-txt)       | :heavy_check_mark: | [99 passing](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v16-20-1-tests-txt-L169)        | 0 failures       | [59 seconds](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v16-20-1-tests-txt-L169)       |
| [18.17.0](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v18-17-0-tests-txt)       | :heavy_check_mark: | [99 passing](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v18-17-0-tests-txt-L169)        | 0 failures       | [54 seconds](https://gist.github.com/mcknasty/71da2aa8dab54c65786a194a8decb205#file-c8-v18-17-0-tests-txt-L169)       |

*Node version 10.x support has been deprecated.