### PR TITLE
try reproducing incorrect coverage when loading querystring

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "test": "cross-env TS_NODE_SKIP_PROJECT=true node ./bin/c8.js mocha --timeout=10000 ./test/*.js",
+    "test-loader": "cross-env TS_NODE_SKIP_PROJECT=true node ./bin/c8.js mocha --timeout=10000 ./test/source-resolved-from-loader.js",
     "coverage": "cross-env TS_NODE_SKIP_PROJECT=true node ./bin/c8.js --check-coverage mocha --timeout=10000 ./test/*.js",
     "test:snap": "cross-env CHAI_JEST_SNAPSHOT_UPDATE_ALL=true npm test",
     "fix": "standard --fix",

--- a/test/fixtures/all/vanilla/main.querystring-import.mjs
+++ b/test/fixtures/all/vanilla/main.querystring-import.mjs
@@ -1,0 +1,38 @@
+import module from 'node:module'
+
+async function resolve (moduleId, context, next) {
+  const result = await next(moduleId, context);
+  const url = new URL(result.url)
+  url.searchParams.set('randomSeed', Math.random());
+  result.url = url.href;
+  return result;
+}
+
+function load(url, context, next) {
+  if (url.includes('main.js')) {
+    const loadedId = url.replace('main.js', 'loaded.js')
+
+    return {
+      shortCircuit: true,
+      format: 'module',
+      source: `import loaded from "${loadedId}";loaded()`,
+    };
+  }
+
+  if (url.includes('loaded.js')) {
+    return {
+      shortCircuit: true,
+      format: 'module',
+      source: 'export default () => true',
+    };
+  }
+
+  return next(url, context);
+}
+
+module.register && module.register(`
+data:text/javascript,
+export ${encodeURIComponent(load)}
+export ${encodeURIComponent(resolve)}`.slice(1))
+
+export default import('./main.js?qs=1')

--- a/test/integration.js
+++ b/test/integration.js
@@ -10,7 +10,6 @@ const nodePath = process.execPath
 const tsNodePath = './node_modules/.bin/ts-node'
 const chaiJestSnapshot = require('chai-jest-snapshot')
 const rimraf = require('rimraf')
-const nodemodule = require('node:module')
 
 require('chai')
   .use(chaiJestSnapshot)
@@ -516,30 +515,6 @@ beforeEach(function () {
         ])
         output.toString('utf8').should.matchSnapshot()
       })
-
-      if (nodemodule.register) {
-        it('reports coverage for query-loaded js files, with accuracy', async () => {
-          const { output } = spawnSync(nodePath, [
-            c8Path,
-            '--temp-directory=tmp/vanilla-all',
-            '--clean=false',
-            '--all=true',
-            '--include=test/fixtures/all/vanilla/**/*.js',
-            '--exclude=**/*.ts', // add an exclude to avoid default excludes of test/**
-            `--merge-async=${mergeAsync}`,
-            nodePath,
-            '--experimental-default-type=module',
-            require.resolve('./fixtures/all/vanilla/main.querystring-import.mjs')
-          ])
-
-          console.log(output.toString('utf8'))
-          output.toString('utf8')
-            .split('\n')
-            .filter(l => l.includes(' loaded.js'))[0]
-            .split('|').some(l => !l.includes(100))
-            .should.equal(true)
-        })
-      }
 
       it('reports coverage for unloaded transpiled ts files as 0 for line, branch and function', () => {
         const { output } = spawnSync(nodePath, [

--- a/test/source-resolved-from-loader.js
+++ b/test/source-resolved-from-loader.js
@@ -1,0 +1,50 @@
+/* global describe, before, beforeEach, it */
+
+const { spawnSync } = require('child_process')
+const c8Path = require.resolve('../bin/c8')
+const nodePath = process.execPath
+const tsNodePath = './node_modules/.bin/ts-node'
+const chaiJestSnapshot = require('chai-jest-snapshot')
+const rimraf = require('rimraf')
+const nodemodule = require('node:module')
+
+require('chai')
+  .use(chaiJestSnapshot)
+  .should()
+
+before(cb => rimraf('tmp', cb))
+
+beforeEach(function () {
+  chaiJestSnapshot.configureUsingMochaContext(this)
+})
+
+;[false, true].forEach((mergeAsync) => {
+  const title = mergeAsync ? 'c8+loader mergeAsync' : 'c8+loader'
+  describe(title, () => {
+    if (nodemodule.register) {
+      it('reports coverage for query-loaded js files, with accuracy', async () => {
+        const { output } = spawnSync(nodePath, [
+          c8Path,
+          '--temp-directory=tmp/vanilla-all',
+          '--clean=false',
+          '--all=true',
+          '--include=test/fixtures/all/vanilla/**/*.js',
+          '--exclude=**/*.ts', // add an exclude to avoid default excludes of test/**
+          `--merge-async=${mergeAsync}`,
+          nodePath,
+          '--experimental-default-type=module',
+          require.resolve('./fixtures/all/vanilla/main.querystring-import.mjs')
+        ])
+
+        // test fails if loaded row looks like this
+        //  loaded.js   |     100 |      100 |     100 |     100 | 
+        output.toString('utf8')
+          .split('\n')
+          .filter(l => l.includes(' loaded.js'))[0]
+          .split('|').filter(l => /\d/.test(l))
+          .every(l => !l.includes(100))
+          .should.equal(true)
+      })
+    }
+  })
+})


### PR DESCRIPTION
This PR attempts to reproduce inaccurate coverage results described here https://github.com/bcoe/c8/issues/325 cc @koshic @coderaiser @shnhrrsn

**update (success): to reproduce the error with this branch, run `npm run test-loader`** The error is not reproduced when all tests run together, as in `npm run test` so a separate `npm run test-loader` command is added to reproduce the issue.

```console
--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------|---------|----------|---------|---------|-------------------
All files     |   82.14 |       80 |      50 |   82.14 |                   
 vanilla      |     100 |      100 |     100 |     100 |                   
  loaded.js   |     100 |      100 |     100 |     100 |                   
  main.js     |     100 |      100 |     100 |     100 |                   
 vanilla/dir  |       0 |        0 |       0 |       0 |                   
  unloaded.js |       0 |        0 |       0 |       0 | 1-5               
--------------|---------|----------|---------|---------|-------------------
```