### PR TITLE
fix: stop installing monocart-coverage-reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ c8 --experimental-monocart --reporter=v8 --reporter=console-details node foo.js
 NOTE: Monocart requires additional `monocart-coverage-reports` to be installed:
 
 ```sh
-npm i monocart-coverage-reports --save-dev
+npm i monocart-coverage-reports@2 --save-dev
 ```
 
 ## Ignoring Uncovered Lines, Functions, and Blocks

--- a/lib/report.js
+++ b/lib/report.js
@@ -103,7 +103,7 @@ class Report {
     try {
       MCR = await this.importMonocart()
     } catch (e) {
-      console.error('--experimental-monocart requires the plugin monocart-coverage-reports. Run: "npm i monocart-coverage-reports --save-dev"')
+      console.error('--experimental-monocart requires the plugin monocart-coverage-reports. Run: "npm i monocart-coverage-reports@2 --save-dev"')
       process.exit(1)
     }
     return MCR

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,15 +30,13 @@
         "chai-jest-snapshot": "^2.0.0",
         "cross-env": "^7.0.3",
         "mocha": "^9.2.2",
+        "monocart-coverage-reports": "^2.8.3",
         "standard": "^16.0.4",
         "ts-node": "^10.7.0",
         "typescript": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "monocart-coverage-reports": "^2.8.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -777,7 +775,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.2.2.tgz",
       "integrity": "sha512-ohlgXexdDTKLNsZz7DSJuCAwmRc8omSS61txOk39W3NOthgKGr1a1jJpZ5BCQe4PlrwMw01OvPQ1Bl3G7Y/uFg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -935,7 +933,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.0.tgz",
       "integrity": "sha512-hVoK898cR71ADj7L1LZWaECLaSkzzPtqGXIaKv4K6Pzb72QgjLVsQaNI+ELDQQshzFvgp5xTPkaYkPGqw3YR+g==",
-      "peer": true
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2834,7 +2832,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lz-utils/-/lz-utils-2.0.2.tgz",
       "integrity": "sha512-i1PJN4hNEevkrvLMqNWCCac1BcB5SRaghywG7HVzWOyVkFOasLCG19ND1sY1F/ZEsM6SnGtoXyBWnmfqOM5r6g==",
-      "peer": true
+      "dev": true
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -3018,17 +3016,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/monocart-code-viewer/-/monocart-code-viewer-1.1.3.tgz",
       "integrity": "sha512-v1dbT8fDr9vjyjEYE035JSC4JXBA/Z034mogVJWRO3khX0/guVwGb69iSIYSzTbR9+KpRKV/C/AscRAkUwP32w==",
-      "peer": true
+      "dev": true
     },
     "node_modules/monocart-coverage-reports": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.8.3.tgz",
       "integrity": "sha512-F6SK6VqKofrnjGtM0Cu9BLgp1ZZPMJhHq8rd8l0vudj3amrVRb+H9UH5X9Xxp4JuGVSODg0XfTDpFOxVjIGjUw==",
-      "peer": true,
-      "workspaces": [
-        "packages/*",
-        "test"
-      ],
+      "dev": true,
       "dependencies": {
         "console-grid": "^2.2.2",
         "eight-colors": "^1.3.0",
@@ -3049,7 +3043,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/monocart-formatter/-/monocart-formatter-3.0.0.tgz",
       "integrity": "sha512-91OQpUb/9iDqvrblUv6ki11Jxi1d3Fp5u2jfVAPl3UdNp9TM+iBleLzXntUS51W0o+zoya3CJjZZ01z2XWn25g==",
-      "peer": true,
+      "dev": true,
       "workspaces": [
         "packages/*"
       ]
@@ -3058,7 +3052,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/monocart-locator/-/monocart-locator-1.0.0.tgz",
       "integrity": "sha512-qIHJ7f99miF2HbVUWAFKR93SfgGYpFPUCQPmW9q1VXU9onxMUFJxhQDdG3HkEteogUbsKB7Gr5MRgjzcIxwTaQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4506,7 +4500,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/turbogrid/-/turbogrid-3.1.0.tgz",
       "integrity": "sha512-IpNYGO26pJkd8c0qSOWVHfg8lYuVhbweaWboy7Xvg/KTI3WjhgYzPS6szPMoxXLEGAhykXagaQCRYl9pGapN6g==",
-      "peer": true
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5488,7 +5482,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.2.2.tgz",
       "integrity": "sha512-ohlgXexdDTKLNsZz7DSJuCAwmRc8omSS61txOk39W3NOthgKGr1a1jJpZ5BCQe4PlrwMw01OvPQ1Bl3G7Y/uFg==",
-      "peer": true
+      "dev": true
     },
     "convert-source-map": {
       "version": "2.0.0",
@@ -5604,7 +5598,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.0.tgz",
       "integrity": "sha512-hVoK898cR71ADj7L1LZWaECLaSkzzPtqGXIaKv4K6Pzb72QgjLVsQaNI+ELDQQshzFvgp5xTPkaYkPGqw3YR+g==",
-      "peer": true
+      "dev": true
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -7007,7 +7001,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lz-utils/-/lz-utils-2.0.2.tgz",
       "integrity": "sha512-i1PJN4hNEevkrvLMqNWCCac1BcB5SRaghywG7HVzWOyVkFOasLCG19ND1sY1F/ZEsM6SnGtoXyBWnmfqOM5r6g==",
-      "peer": true
+      "dev": true
     },
     "make-dir": {
       "version": "4.0.0",
@@ -7143,13 +7137,13 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/monocart-code-viewer/-/monocart-code-viewer-1.1.3.tgz",
       "integrity": "sha512-v1dbT8fDr9vjyjEYE035JSC4JXBA/Z034mogVJWRO3khX0/guVwGb69iSIYSzTbR9+KpRKV/C/AscRAkUwP32w==",
-      "peer": true
+      "dev": true
     },
     "monocart-coverage-reports": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.8.3.tgz",
       "integrity": "sha512-F6SK6VqKofrnjGtM0Cu9BLgp1ZZPMJhHq8rd8l0vudj3amrVRb+H9UH5X9Xxp4JuGVSODg0XfTDpFOxVjIGjUw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "console-grid": "^2.2.2",
         "eight-colors": "^1.3.0",
@@ -7167,13 +7161,13 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/monocart-formatter/-/monocart-formatter-3.0.0.tgz",
       "integrity": "sha512-91OQpUb/9iDqvrblUv6ki11Jxi1d3Fp5u2jfVAPl3UdNp9TM+iBleLzXntUS51W0o+zoya3CJjZZ01z2XWn25g==",
-      "peer": true
+      "dev": true
     },
     "monocart-locator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/monocart-locator/-/monocart-locator-1.0.0.tgz",
       "integrity": "sha512-qIHJ7f99miF2HbVUWAFKR93SfgGYpFPUCQPmW9q1VXU9onxMUFJxhQDdG3HkEteogUbsKB7Gr5MRgjzcIxwTaQ==",
-      "peer": true
+      "dev": true
     },
     "ms": {
       "version": "2.1.3",
@@ -8210,7 +8204,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/turbogrid/-/turbogrid-3.1.0.tgz",
       "integrity": "sha512-IpNYGO26pJkd8c0qSOWVHfg8lYuVhbweaWboy7Xvg/KTI3WjhgYzPS6szPMoxXLEGAhykXagaQCRYl9pGapN6g==",
-      "peer": true
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "ts-node": "^10.7.0",
     "typescript": "^5.0.0"
   },
-  "peerDependencies": {
-    "monocart-coverage-reports": "^2.8.3"
+  "c8Requirements": {
+    "monocart-coverage-reports": "^2"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "chai-jest-snapshot": "^2.0.0",
     "cross-env": "^7.0.3",
     "mocha": "^9.2.2",
+    "monocart-coverage-reports": "^2.8.3",
     "standard": "^16.0.4",
     "ts-node": "^10.7.0",
     "typescript": "^5.0.0"

--- a/test/integration.js.snap
+++ b/test/integration.js.snap
@@ -748,7 +748,7 @@ All files          |     100 |      100 |     100 |     100 |
 `;
 
 exports[`c8 mergeAsync monocart report check import monocart 1`] = `
-",,--experimental-monocart requires the plugin monocart-coverage-reports. Run: \\"npm i monocart-coverage-reports --save-dev\\"
+",,--experimental-monocart requires the plugin monocart-coverage-reports. Run: \\"npm i monocart-coverage-reports@2 --save-dev\\"
 "
 `;
 
@@ -1146,7 +1146,7 @@ All files          |     100 |      100 |     100 |     100 |
 `;
 
 exports[`c8 monocart report check import monocart 1`] = `
-",,--experimental-monocart requires the plugin monocart-coverage-reports. Run: \\"npm i monocart-coverage-reports --save-dev\\"
+",,--experimental-monocart requires the plugin monocart-coverage-reports. Run: \\"npm i monocart-coverage-reports@2 --save-dev\\"
 "
 `;
 


### PR DESCRIPTION
Since npm@7 peerDependencies installs deps. Move to the approach used by [pixijs](https://github.com/pixijs/pixijs/pull/8630).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bcoe/c8/blob/main/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] `npm test`, tests passing
- [ ] `npm run test:snap` (to update the snapshot)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
