### PR TITLE
Make monocart-coverage-reports an optional peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,14 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "chai-jest-snapshot": "^2.0.0",
         "cross-env": "^7.0.3",
         "mocha": "^9.2.2",
-        "monocart-coverage-reports": "^2.8.3",
         "standard": "^16.0.4",
         "ts-node": "^10.7.0",
         "typescript": "^5.0.0"
@@ -783,7 +782,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.2.2.tgz",
       "integrity": "sha512-ohlgXexdDTKLNsZz7DSJuCAwmRc8omSS61txOk39W3NOthgKGr1a1jJpZ5BCQe4PlrwMw01OvPQ1Bl3G7Y/uFg==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -941,7 +941,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.0.tgz",
       "integrity": "sha512-hVoK898cR71ADj7L1LZWaECLaSkzzPtqGXIaKv4K6Pzb72QgjLVsQaNI+ELDQQshzFvgp5xTPkaYkPGqw3YR+g==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2840,7 +2841,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lz-utils/-/lz-utils-2.0.2.tgz",
       "integrity": "sha512-i1PJN4hNEevkrvLMqNWCCac1BcB5SRaghywG7HVzWOyVkFOasLCG19ND1sY1F/ZEsM6SnGtoXyBWnmfqOM5r6g==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -3024,13 +3026,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/monocart-code-viewer/-/monocart-code-viewer-1.1.3.tgz",
       "integrity": "sha512-v1dbT8fDr9vjyjEYE035JSC4JXBA/Z034mogVJWRO3khX0/guVwGb69iSIYSzTbR9+KpRKV/C/AscRAkUwP32w==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/monocart-coverage-reports": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.8.3.tgz",
       "integrity": "sha512-F6SK6VqKofrnjGtM0Cu9BLgp1ZZPMJhHq8rd8l0vudj3amrVRb+H9UH5X9Xxp4JuGVSODg0XfTDpFOxVjIGjUw==",
-      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "console-grid": "^2.2.2",
         "eight-colors": "^1.3.0",
@@ -3051,7 +3055,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/monocart-formatter/-/monocart-formatter-3.0.0.tgz",
       "integrity": "sha512-91OQpUb/9iDqvrblUv6ki11Jxi1d3Fp5u2jfVAPl3UdNp9TM+iBleLzXntUS51W0o+zoya3CJjZZ01z2XWn25g==",
-      "dev": true,
+      "optional": true,
+      "peer": true,
       "workspaces": [
         "packages/*"
       ]
@@ -3060,7 +3065,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/monocart-locator/-/monocart-locator-1.0.0.tgz",
       "integrity": "sha512-qIHJ7f99miF2HbVUWAFKR93SfgGYpFPUCQPmW9q1VXU9onxMUFJxhQDdG3HkEteogUbsKB7Gr5MRgjzcIxwTaQ==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4508,7 +4514,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/turbogrid/-/turbogrid-3.1.0.tgz",
       "integrity": "sha512-IpNYGO26pJkd8c0qSOWVHfg8lYuVhbweaWboy7Xvg/KTI3WjhgYzPS6szPMoxXLEGAhykXagaQCRYl9pGapN6g==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5490,7 +5497,8 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.2.2.tgz",
       "integrity": "sha512-ohlgXexdDTKLNsZz7DSJuCAwmRc8omSS61txOk39W3NOthgKGr1a1jJpZ5BCQe4PlrwMw01OvPQ1Bl3G7Y/uFg==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "convert-source-map": {
       "version": "2.0.0",
@@ -5606,7 +5614,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.0.tgz",
       "integrity": "sha512-hVoK898cR71ADj7L1LZWaECLaSkzzPtqGXIaKv4K6Pzb72QgjLVsQaNI+ELDQQshzFvgp5xTPkaYkPGqw3YR+g==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -7009,7 +7018,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lz-utils/-/lz-utils-2.0.2.tgz",
       "integrity": "sha512-i1PJN4hNEevkrvLMqNWCCac1BcB5SRaghywG7HVzWOyVkFOasLCG19ND1sY1F/ZEsM6SnGtoXyBWnmfqOM5r6g==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "make-dir": {
       "version": "4.0.0",
@@ -7145,13 +7155,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/monocart-code-viewer/-/monocart-code-viewer-1.1.3.tgz",
       "integrity": "sha512-v1dbT8fDr9vjyjEYE035JSC4JXBA/Z034mogVJWRO3khX0/guVwGb69iSIYSzTbR9+KpRKV/C/AscRAkUwP32w==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "monocart-coverage-reports": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.8.3.tgz",
       "integrity": "sha512-F6SK6VqKofrnjGtM0Cu9BLgp1ZZPMJhHq8rd8l0vudj3amrVRb+H9UH5X9Xxp4JuGVSODg0XfTDpFOxVjIGjUw==",
-      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "console-grid": "^2.2.2",
         "eight-colors": "^1.3.0",
@@ -7169,13 +7181,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/monocart-formatter/-/monocart-formatter-3.0.0.tgz",
       "integrity": "sha512-91OQpUb/9iDqvrblUv6ki11Jxi1d3Fp5u2jfVAPl3UdNp9TM+iBleLzXntUS51W0o+zoya3CJjZZ01z2XWn25g==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "monocart-locator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/monocart-locator/-/monocart-locator-1.0.0.tgz",
       "integrity": "sha512-qIHJ7f99miF2HbVUWAFKR93SfgGYpFPUCQPmW9q1VXU9onxMUFJxhQDdG3HkEteogUbsKB7Gr5MRgjzcIxwTaQ==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "ms": {
       "version": "2.1.3",
@@ -8212,7 +8226,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/turbogrid/-/turbogrid-3.1.0.tgz",
       "integrity": "sha512-IpNYGO26pJkd8c0qSOWVHfg8lYuVhbweaWboy7Xvg/KTI3WjhgYzPS6szPMoxXLEGAhykXagaQCRYl9pGapN6g==",
-      "dev": true
+      "optional": true,
+      "peer": true
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,13 @@
     "ts-node": "^10.7.0",
     "typescript": "^5.0.0"
   },
-  "c8Requirements": {
+  "peerDependencies": {
     "monocart-coverage-reports": "^2"
+  },
+  "peerDependenciesMeta": {
+    "monocart-coverage-reports": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "chai-jest-snapshot": "^2.0.0",
     "cross-env": "^7.0.3",
     "mocha": "^9.2.2",
-    "monocart-coverage-reports": "^2.8.3",
     "standard": "^16.0.4",
     "ts-node": "^10.7.0",
     "typescript": "^5.0.0"


### PR DESCRIPTION
I noticed in https://github.com/bcoe/c8/commit/13979a76b5b44fc6758f350bae4cb3febd60d75e that you fixed it being a "required" peer dep by not declaring it at all.

Package managers like `pnpm` (or others) may use a stricter `node_modules` layout which would prevent `c8` from accessing `monocart-coverage-reports` because it's not a declared dependency.

Instead of not declaring the dep, you can still use a peer dep but just mark it optional. Users installing `c8` will not get `monocart-coverage-reports` automatically, which I believe is what you intended. But, installing it later will ensure that it's correctly linked.

As an example, see https://github.com/microsoft/TypeChat/blob/ce83b7f63f19786106f82a37ca154bbb579d960b/typescript/package.json#L43-L54, which declares deps on libraries that can plug into TypeChat, but are not hard deps.

(I also find this to more clearly show intent to people reading the package or analyzing their deps.)