### PR TITLE
Fix issue #498 - c8 CLI doesn't work properly when executed in a sub-directory of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,9 @@ Here is a list of common options. Run `c8 --help` for the full list and document
 | `-c`, `--config` | path to JSON configuration file | `string` | See above |
 | `-r`, `--reporter` | coverage reporter(s) to use | `Array<string>` | `['text']` |
 | `-o`, `--reports-dir`, `--report-dir` | directory where coverage reports will be output to | `string` | `./coverage` |
-| `--all` | see [section below](#checking-for-full-source-coverage-using---all) for more info | `boolean` | `false` |
-| `--src` | see [section below](#checking-for-full-source-coverage-using---all) for more info | `Array<string>` | `[process.cwd()]`|
-| `-n`, `--include` | see [section below](#checking-for-full-source-coverage-using---all) for more info | `Array<string>` | `[]` (include all files) |
-| `-x`, `--exclude` | see [section below](#checking-for-full-source-coverage-using---all) for more info | `Array<string>` | [list](https://github.com/istanbuljs/schema/blob/master/default-exclude.js) |
+| `-n`, `--include` | see [section below](#checking-for-full-source-coverage) for more info | `Array<string>` | `[]` (include all files) |
+| `-x`, `--exclude` | see [section below](#checking-for-full-source-coverage) for more info | `Array<string>` | [list](https://github.com/istanbuljs/schema/blob/master/default-exclude.js) |
 | `--exclude-after-remap` | see [section below](#exclude-after-remap) for more info | `boolean` | `false` |
-| `-e`, `--extension` | only files matching these extensions will show coverage | `string \| Array<string>` | [list](https://github.com/istanbuljs/schema/blob/master/default-extension.js) |
 | `--skip-full` | do not show files with 100% statement, branch, and function coverage | `boolean` | `false` |
 | `--check-coverage` | check whether coverage is within thresholds provided | `boolean` | `false` |
 | `--per-file` | check thresholds per file | `boolean` | `false` |
@@ -45,16 +42,14 @@ Here is a list of common options. Run `c8 --help` for the full list and document
 | `--clean` | should temp files be deleted before script execution | `boolean` | `true` |
 | `--experimental-monocart` | see [section below](#using-monocart-coverage-reports-experimental) for more info | `boolean` | `false` |
 
-## Checking for "full" source coverage using `--all`
+## Checking for "full" source coverage
 
-By default v8 will only give us coverage for files that were loaded by the engine. If there are source files in your
+By default, v8 will only give us coverage for files that were loaded by the engine. If there are source files in your
 project that are flexed in production but not in your tests, your coverage numbers will not reflect this. For example,
 if your project's `main.js` loads `a.js` and `b.js` but your unit tests only load `a.js` your total coverage
 could show as `100%` for `a.js` when in fact both `main.js` and `b.js` are uncovered.
 
-By supplying `--all` to c8, all files in directories specified with `--src` (defaults to `cwd`) that pass the `--include`
-and `--exclude` flag checks, will be loaded into the report. If any of those files remain uncovered they will be factored
-into the report with a default of 0% coverage.
+C8 overcomes this issue: all files that pass the `--include` and `--exclude` flag checks will be loaded into the report. If any of those files remain uncovered, they will be factored into the report with a default of 0% coverage.
 
 ## SourceMap Support
 

--- a/lib/commands/check-coverage.js
+++ b/lib/commands/check-coverage.js
@@ -20,17 +20,16 @@ exports.handler = function (argv) {
   }
 
   const report = Report({
+    basePath: argv.basePath,
     include: argv.include,
     exclude: argv.exclude,
-    extension: argv.extension,
     reporter: Array.isArray(argv.reporter) ? argv.reporter : [argv.reporter],
     reportsDirectory: argv['reports-dir'],
     tempDirectory: argv.tempDirectory,
     watermarks: argv.watermarks,
     resolve: argv.resolve,
     omitRelative: argv.omitRelative,
-    wrapperLength: argv.wrapperLength,
-    all: argv.all
+    wrapperLength: argv.wrapperLength
   })
   exports.checkCoverages(argv, report)
 }

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -19,9 +19,9 @@ exports.outputReport = async function (argv) {
     argv.statements = 100
   }
   const report = Report({
+    basePath: argv.basePath,
     include: argv.include,
     exclude: argv.exclude,
-    extension: argv.extension,
     excludeAfterRemap: argv.excludeAfterRemap,
     reporter: Array.isArray(argv.reporter) ? argv.reporter : [argv.reporter],
     reportsDirectory: argv['reports-dir'],
@@ -31,11 +31,7 @@ exports.outputReport = async function (argv) {
     resolve: argv.resolve,
     omitRelative: argv.omitRelative,
     wrapperLength: argv.wrapperLength,
-    all: argv.all,
-    allowExternal: argv.allowExternal,
-    src: argv.src,
     skipFull: argv.skipFull,
-    excludeNodeModules: argv.excludeNodeModules,
     mergeAsync: argv.mergeAsync,
     monocartArgv: (argv.experimentalMonocart || process.env.EXPERIMENTAL_MONOCART) ? argv : null
   })

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -1,13 +1,14 @@
 const defaultExclude = require('@istanbuljs/schema/default-exclude')
-const defaultExtension = require('@istanbuljs/schema/default-extension')
 const findUp = require('find-up')
 const { readFileSync } = require('fs')
 const Yargs = require('yargs/yargs')
 const { applyExtends } = require('yargs/helpers')
 const parser = require('yargs-parser')
-const { resolve } = require('path')
+const { resolve, dirname } = require('path')
 
 function buildYargs (withCommands = false) {
+  const configurationFile = findUp.sync(['.c8rc', '.c8rc.json', '.nycrc', '.nycrc.json'])
+
   const yargs = Yargs([])
     .usage('$0 [opts] [script] [opts]')
     .options('config', {
@@ -18,7 +19,7 @@ function buildYargs (withCommands = false) {
         const config = JSON.parse(readFileSync(path))
         return applyExtends(config, process.cwd(), true)
       },
-      default: () => findUp.sync(['.c8rc', '.c8rc.json', '.nycrc', '.nycrc.json'])
+      default: () => configurationFile
     })
     .option('reporter', {
       alias: 'r',
@@ -32,25 +33,6 @@ function buildYargs (withCommands = false) {
       describe: 'directory where coverage reports will be output to',
       default: './coverage'
     })
-    .options('all', {
-      default: false,
-      type: 'boolean',
-      group: 'Reporting options',
-      describe: 'supplying --all will cause c8 to consider all src files in the current working directory ' +
-        'when the determining coverage. Respects include/exclude.'
-    })
-    .options('src', {
-      default: undefined,
-      type: 'string',
-      group: 'Reporting options',
-      describe: 'supplying --src will override cwd as the default location where --all looks for src files. --src can be ' +
-        'supplied multiple times and each directory will be included. This allows for workspaces spanning multiple projects'
-    })
-    .option('exclude-node-modules', {
-      default: true,
-      type: 'boolean',
-      describe: 'whether or not to exclude all node_module folders (i.e. **/node_modules/**) by default'
-    })
     .option('include', {
       alias: 'n',
       default: [],
@@ -62,12 +44,6 @@ function buildYargs (withCommands = false) {
       default: defaultExclude,
       group: 'Reporting options',
       describe: 'a list of specific files and directories that should be excluded from coverage (glob patterns are supported)'
-    })
-    .option('extension', {
-      alias: 'e',
-      default: defaultExtension,
-      group: 'Reporting options',
-      describe: 'a list of specific file extensions that should be covered'
     })
     .option('exclude-after-remap', {
       alias: 'a',
@@ -146,12 +122,6 @@ function buildYargs (withCommands = false) {
       type: 'boolean',
       describe: 'omit any paths that are not absolute, e.g., internal/net.js'
     })
-    .options('allowExternal', {
-      default: false,
-      type: 'boolean',
-      describe: 'supplying --allowExternal will cause c8 to allow files from outside of your cwd. This applies both to ' +
-        'files discovered in coverage temp files and also src files discovered if using the --all flag.'
-    })
     .options('merge-async', {
       default: false,
       type: 'boolean',
@@ -166,9 +136,24 @@ function buildYargs (withCommands = false) {
     .pkgConf('c8')
     .demandCommand(1)
     .check((argv) => {
+      if (typeof argv.exclude === 'string') {
+        argv.exclude = [argv.exclude]
+      }
+
+      if (typeof argv.include === 'string') {
+        argv.include = [argv.include]
+      }
+
       if (!argv.tempDirectory) {
         argv.tempDirectory = resolve(argv.reportsDir, 'tmp')
       }
+
+      if (configurationFile) {
+        argv.basePath = dirname(configurationFile)
+      } else {
+        argv.basePath = process.cwd()
+      }
+
       return true
     })
     .epilog('visit https://git.io/vHysA for list of available reporters')

--- a/lib/report.js
+++ b/lib/report.js
@@ -9,18 +9,19 @@ try {
   ;({ readFile } = require('fs').promises)
 }
 const { readdirSync, readFileSync, statSync } = require('fs')
-const { isAbsolute, resolve, extname } = require('path')
+const { isAbsolute, resolve, join } = require('path')
 const { pathToFileURL, fileURLToPath } = require('url')
 const getSourceMapFromFile = require('./source-map-from-file')
 // TODO: switch back to @c88/v8-coverage once patch is landed.
 const v8toIstanbul = require('v8-to-istanbul')
 const util = require('util')
 const debuglog = util.debuglog('c8')
+const { glob } = require('glob')
 
 class Report {
   constructor ({
+    basePath,
     exclude,
-    extension,
     excludeAfterRemap,
     include,
     reporter,
@@ -31,14 +32,15 @@ class Report {
     omitRelative,
     wrapperLength,
     resolve: resolvePaths,
-    all,
-    src,
-    allowExternal = false,
     skipFull,
-    excludeNodeModules,
     mergeAsync,
     monocartArgv
   }) {
+    const resolvePattern = (pattern) => {
+      return join(basePath, pattern)
+    }
+
+    this.include = include.map(resolvePattern)
     this.reporter = reporter
     this.reporterOptions = reporterOptions || {}
     this.reportsDirectory = reportsDirectory
@@ -46,32 +48,20 @@ class Report {
     this.watermarks = watermarks
     this.resolve = resolvePaths
     this.exclude = new Exclude({
-      exclude: exclude,
-      include: include,
-      extension: extension,
-      relativePath: !allowExternal,
-      excludeNodeModules: excludeNodeModules
+      exclude: exclude.map(resolvePattern),
+      include: this.include,
+      extension: false,
+      relativePath: false,
+      excludeNodeModules: false
     })
     this.excludeAfterRemap = excludeAfterRemap
     this.shouldInstrumentCache = new Map()
     this.omitRelative = omitRelative
     this.sourceMapCache = {}
     this.wrapperLength = wrapperLength
-    this.all = all
-    this.src = this._getSrc(src)
     this.skipFull = skipFull
     this.mergeAsync = mergeAsync
     this.monocartArgv = monocartArgv
-  }
-
-  _getSrc (src) {
-    if (typeof src === 'string') {
-      return [src]
-    } else if (Array.isArray(src)) {
-      return src
-    } else {
-      return [process.cwd()]
-    }
   }
 
   async run () {
@@ -151,22 +141,6 @@ class Report {
       })
     }
 
-    // --all: add empty coverage for all files
-    function getAllOptions () {
-      if (!argv.all) {
-        return
-      }
-
-      const src = argv.src
-      const workingDirs = Array.isArray(src) ? src : (typeof src === 'string' ? [src] : [process.cwd()])
-      return {
-        dir: workingDirs,
-        filter: (filePath) => {
-          return exclude.shouldInstrument(filePath)
-        }
-      }
-    }
-
     function initPct (summary) {
       Object.keys(summary).forEach(k => {
         if (summary[k].pct === '') {
@@ -191,8 +165,6 @@ class Report {
 
       inline: argv.inline,
       lcov: argv.lcov,
-
-      all: getAllOptions(),
 
       clean: argv.clean,
 
@@ -319,6 +291,7 @@ class Report {
     const fileIndex = new Set() // Set<string>
     for (const v8ProcessCov of this._loadReports()) {
       if (this._isCoverageObject(v8ProcessCov)) {
+        // source-map-cache contains the list of entry points
         if (v8ProcessCov['source-map-cache']) {
           Object.assign(this.sourceMapCache, this._normalizeSourceMapCache(v8ProcessCov['source-map-cache']))
         }
@@ -326,12 +299,10 @@ class Report {
       }
     }
 
-    if (this.all) {
-      const emptyReports = this._includeUncoveredFiles(fileIndex)
-      v8ProcessCovs.unshift({
-        result: emptyReports
-      })
-    }
+    const emptyReports = this._includeUncoveredFiles(fileIndex)
+    v8ProcessCovs.unshift({
+      result: emptyReports
+    })
 
     return mergeProcessCovs(v8ProcessCovs)
   }
@@ -374,54 +345,48 @@ class Report {
       }
     }
 
-    if (this.all) {
-      const emptyReports = this._includeUncoveredFiles(fileIndex)
-      const emptyReport = {
-        result: emptyReports
-      }
-
-      mergedCov = mergeProcessCovs([emptyReport, mergedCov])
+    const emptyReports = this._includeUncoveredFiles(fileIndex)
+    const emptyReport = {
+      result: emptyReports
     }
+
+    mergedCov = mergeProcessCovs([emptyReport, mergedCov])
 
     return mergedCov
   }
 
   /**
    * Adds empty coverage reports to account for uncovered/untested code.
-   * This is only done when the `--all` flag is present.
    *
    * @param {Set} fileIndex list of files that have coverage
    * @returns {Array} list of empty coverage reports
    */
   _includeUncoveredFiles (fileIndex) {
     const emptyReports = []
-    const workingDirs = this.src
-    const { extension } = this.exclude
+    const workingDirs = this.include
     for (const workingDir of workingDirs) {
-      this.exclude.globSync(workingDir).forEach((f) => {
-        const fullPath = resolve(workingDir, f)
+      glob.sync(workingDir, {
+        ignore: this.exclude.exclude
+      }).forEach((fullPath) => {
         if (!fileIndex.has(fullPath)) {
-          const ext = extname(fullPath)
-          if (extension.includes(ext)) {
-            const stat = statSync(fullPath)
-            const sourceMap = getSourceMapFromFile(fullPath)
-            if (sourceMap) {
-              this.sourceMapCache[pathToFileURL(fullPath)] = { data: sourceMap }
-            }
-            emptyReports.push({
-              scriptId: 0,
-              url: resolve(fullPath),
-              functions: [{
-                functionName: '(empty-report)',
-                ranges: [{
-                  startOffset: 0,
-                  endOffset: stat.size,
-                  count: 0
-                }],
-                isBlockCoverage: true
-              }]
-            })
+          const stat = statSync(fullPath)
+          const sourceMap = getSourceMapFromFile(fullPath)
+          if (sourceMap) {
+            this.sourceMapCache[pathToFileURL(fullPath)] = { data: sourceMap }
           }
+          emptyReports.push({
+            scriptId: 0,
+            url: resolve(fullPath),
+            functions: [{
+              functionName: '(empty-report)',
+              ranges: [{
+                startOffset: 0,
+                endOffset: stat.size,
+                count: 0
+              }],
+              isBlockCoverage: true
+            }]
+          })
         }
       })
     }
@@ -531,7 +496,13 @@ class Report {
       return cacheResult
     }
 
-    const result = this.exclude.shouldInstrument(filename)
+    // entry points must always be instrumented, by nature: they are the tested artifacts
+    let result = this.sourceMapCache[pathToFileURL(filename)] !== undefined;
+
+    if (!result) {
+      result = this.exclude.shouldInstrument(filename)
+    }
+
     this.shouldInstrumentCache.set(filename, result)
     return result
   }

--- a/test/fixtures/report/report-multi-dir-external.js
+++ b/test/fixtures/report/report-multi-dir-external.js
@@ -1,12 +1,13 @@
 const Report = require('../../../lib/report')
 const report = new Report({
-  include: ['**/*.js'],
+  basePath: '.',
+  include: [
+    '../multidir1/**/*.js',
+    '../multidir2/**/*.js'
+  ],
   exclude: [],
   reporter: ['text'],
   tempDirectory: './temp',
-  omitRelative: true,
-  all: true,
-  src: ['../multidir1/', '../multidir2/'],
-  allowExternal: true
+  omitRelative: true
 })
 report.run()

--- a/test/fixtures/report/report-single-dir-external.js
+++ b/test/fixtures/report/report-single-dir-external.js
@@ -1,12 +1,10 @@
 const Report = require('../../../lib/report')
 const report = new Report({
-  include: ['**/*.js'],
+  basePath: '.',
+  include: ['../multidir1/**/*.js'],
   exclude: [],
   reporter: ['text'],
   tempDirectory: './temp',
-  omitRelative: true,
-  all: true,
-  src: '../multidir1/',
-  allowExternal: true
+  omitRelative: true
 })
 report.run()

--- a/test/integration.js.snap
+++ b/test/integration.js.snap
@@ -39,14 +39,14 @@ exports[`c8 --all reports coverage for unloaded js files as 0 for line, branch a
 positive
 negative
 --------------|---------|----------|---------|---------|-------------------
-File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 --------------|---------|----------|---------|---------|-------------------
-All files     |   64.28 |    66.66 |      50 |   64.28 |                   
- vanilla      |   78.26 |       75 |     100 |   78.26 |                   
-  loaded.js   |   73.68 |    71.42 |     100 |   73.68 | 4-5,16-18         
-  main.js     |     100 |      100 |     100 |     100 |                   
- vanilla/dir  |       0 |        0 |       0 |       0 |                   
-  unloaded.js |       0 |        0 |       0 |       0 | 1-5               
+All files     |   64.28 |    66.66 |      50 |   64.28 |
+ vanilla      |   78.26 |       75 |     100 |   78.26 |
+  loaded.js   |   73.68 |    71.42 |     100 |   73.68 | 4-5,16-18
+  main.js     |     100 |      100 |     100 |     100 |
+ vanilla/dir  |       0 |        0 |       0 |       0 |
+  unloaded.js |       0 |        0 |       0 |       0 | 1-5
 --------------|---------|----------|---------|---------|-------------------
 ,"
 `;
@@ -56,14 +56,14 @@ exports[`c8 --all reports coverage for unloaded transpiled ts files as 0 for lin
 positive
 negative
 -----------------|---------|----------|---------|---------|-------------------
-File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 -----------------|---------|----------|---------|---------|-------------------
-All files        |   64.28 |    57.14 |      50 |   64.28 |                   
- ts-compiled     |   78.26 |    66.66 |     100 |   78.26 |                   
-  loaded.ts      |   73.68 |    66.66 |     100 |   73.68 | 4-5,16-18         
-  main.ts        |     100 |      100 |     100 |     100 |                   
- ts-compiled/dir |       0 |        0 |       0 |       0 |                   
-  unloaded.ts    |       0 |        0 |       0 |       0 | 1-5               
+All files        |   64.28 |    57.14 |      50 |   64.28 |
+ ts-compiled     |   78.26 |    66.66 |     100 |   78.26 |
+  loaded.ts      |   73.68 |    66.66 |     100 |   73.68 | 4-5,16-18
+  main.ts        |     100 |      100 |     100 |     100 |
+ ts-compiled/dir |       0 |        0 |       0 |       0 |
+  unloaded.ts    |       0 |        0 |       0 |       0 | 1-5
 -----------------|---------|----------|---------|---------|-------------------
 ,"
 `;
@@ -73,14 +73,14 @@ exports[`c8 --all reports coverage for unloaded ts files as 0 for line, branch a
 positive
 negative
 --------------|---------|----------|---------|---------|-------------------
-File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 --------------|---------|----------|---------|---------|-------------------
-All files     |   64.28 |    57.14 |      50 |   64.28 |                   
- ts-only      |   78.26 |    66.66 |     100 |   78.26 |                   
-  loaded.ts   |   73.68 |    66.66 |     100 |   73.68 | 4-5,16-18         
-  main.ts     |     100 |      100 |     100 |     100 |                   
- ts-only/dir  |       0 |        0 |       0 |       0 |                   
-  unloaded.ts |       0 |        0 |       0 |       0 | 1-5               
+All files     |   64.28 |    57.14 |      50 |   64.28 |
+ ts-only      |   78.26 |    66.66 |     100 |   78.26 |
+  loaded.ts   |   73.68 |    66.66 |     100 |   73.68 | 4-5,16-18
+  main.ts     |     100 |      100 |     100 |     100 |
+ ts-only/dir  |       0 |        0 |       0 |       0 |
+  unloaded.ts |       0 |        0 |       0 |       0 | 1-5
 --------------|---------|----------|---------|---------|-------------------
 ,"
 `;
@@ -90,14 +90,14 @@ exports[`c8 --all should allow for --all to be used in conjunction with --check-
 positive
 negative
 --------------|---------|----------|---------|---------|-------------------
-File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 --------------|---------|----------|---------|---------|-------------------
-All files     |   64.28 |    66.66 |      50 |   64.28 |                   
- vanilla      |   78.26 |       75 |     100 |   78.26 |                   
-  loaded.js   |   73.68 |    71.42 |     100 |   73.68 | 4-5,16-18         
-  main.js     |     100 |      100 |     100 |     100 |                   
- vanilla/dir  |       0 |        0 |       0 |       0 |                   
-  unloaded.js |       0 |        0 |       0 |       0 | 1-5               
+All files     |   64.28 |    66.66 |      50 |   64.28 |
+ vanilla      |   78.26 |       75 |     100 |   78.26 |
+  loaded.js   |   73.68 |    71.42 |     100 |   73.68 | 4-5,16-18
+  main.js     |     100 |      100 |     100 |     100 |
+ vanilla/dir  |       0 |        0 |       0 |       0 |
+  unloaded.js |       0 |        0 |       0 |       0 | 1-5
 --------------|---------|----------|---------|---------|-------------------
 ,ERROR: Coverage for lines (64.28%) does not meet global threshold (100%)
 ERROR: Coverage for branches (66.66%) does not meet global threshold (82%)
@@ -154,69 +154,69 @@ hey
 what
 hey
 ---------------------------------------|---------|----------|---------|---------|------------------------
-File                                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s      
+File                                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 ---------------------------------------|---------|----------|---------|---------|------------------------
-All files                              |    3.21 |    12.24 |    6.38 |    3.21 |                        
- c8                                    |       0 |        0 |       0 |       0 |                        
-  index.js                             |       0 |        0 |       0 |       0 | 1                      
- c8/bin                                |       0 |        0 |       0 |       0 |                        
-  c8.js                                |       0 |        0 |       0 |       0 | 1-43                   
- c8/coverage                           |       0 |        0 |       0 |       0 |                        
-  block-navigation.js                  |       0 |        0 |       0 |       0 | 1-87                   
-  prettify.js                          |       0 |        0 |       0 |       0 | 1-2                    
-  sorter.js                            |       0 |        0 |       0 |       0 | 1-196                  
- c8/lib                                |       0 |        0 |       0 |       0 |                        
-  parse-args.js                        |       0 |        0 |       0 |       0 | 1-229                  
-  report.js                            |       0 |        0 |       0 |       0 | 1-542                  
-  source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100                  
- c8/lib/commands                       |       0 |        0 |       0 |       0 |                        
-  check-coverage.js                    |       0 |        0 |       0 |       0 | 1-70                   
-  report.js                            |       0 |        0 |       0 |       0 | 1-44                   
- c8/test/fixtures                      |   29.08 |    35.29 |      20 |   29.08 |                        
-  async.js                             |     100 |      100 |     100 |     100 |                        
-  c8-ignore-next.js                    |   54.54 |        0 |       0 |   54.54 | 1,3-4,9,12,17-19,21-22 
-  c8-ignore-start-stop.js              |    61.9 |        0 |       0 |    61.9 | 1-4,10,16-18           
-  computed-method.js                   |       0 |        0 |       0 |       0 | 1-15                   
-  custom-ext.special                   |      75 |    66.66 |   33.33 |      75 | 14-16,18-20            
-  custom-ext2.special                  |       0 |        0 |       0 |       0 | 1-24                   
-  import-mcr.js                        |       0 |        0 |       0 |       0 | 1-12                   
-  issue-254.js                         |   28.57 |        0 |       0 |   28.57 | 1-2,5-7                
-  multiple-spawn.js                    |       0 |        0 |       0 |       0 | 1-12                   
-  normal.js                            |       0 |        0 |       0 |       0 | 1-24                   
-  shebang.js                           |       0 |        0 |       0 |       0 | 1-8                    
-  subprocess.js                        |       0 |        0 |       0 |       0 | 1-15                   
- c8/test/fixtures/all/ts-compiled      |       0 |        0 |       0 |       0 |                        
-  loaded.ts                            |       0 |        0 |       0 |       0 | 1-19                   
-  main.ts                              |       0 |        0 |       0 |       0 | 1-4                    
- c8/test/fixtures/all/ts-compiled/dir  |       0 |        0 |       0 |       0 |                        
-  unloaded.ts                          |       0 |        0 |       0 |       0 | 1-5                    
- c8/test/fixtures/all/vanilla          |       0 |        0 |       0 |       0 |                        
-  loaded.js                            |       0 |        0 |       0 |       0 | 1-19                   
-  main.js                              |       0 |        0 |       0 |       0 | 1-4                    
- c8/test/fixtures/all/vanilla/dir      |       0 |        0 |       0 |       0 |                        
-  unloaded.js                          |       0 |        0 |       0 |       0 | 1-5                    
- c8/test/fixtures/multidir1            |       0 |        0 |       0 |       0 |                        
-  file1.js                             |       0 |        0 |       0 |       0 | 1                      
- c8/test/fixtures/multidir2            |       0 |        0 |       0 |       0 |                        
-  file2.js                             |       0 |        0 |       0 |       0 | 1                      
- c8/test/fixtures/report               |       0 |        0 |       0 |       0 |                        
-  allowExternal.js                     |       0 |        0 |       0 |       0 | 1                      
-  report-multi-dir-external.js         |       0 |        0 |       0 |       0 | 1-12                   
-  report-single-dir-external.js        |       0 |        0 |       0 |       0 | 1-12                   
-  srcOverride.js                       |       0 |        0 |       0 |       0 | 1                      
- c8/test/fixtures/source-maps          |       0 |        0 |       0 |       0 |                        
-  branches.js                          |       0 |        0 |       0 |       0 | 1-20                   
-  fake-source-map.js                   |       0 |        0 |       0 |       0 | 1-7                    
- c8/test/fixtures/source-maps/branches |       0 |        0 |       0 |       0 |                        
-  branch-1.js                          |       0 |        0 |       0 |       0 | 1-12                   
-  branch-2.js                          |       0 |        0 |       0 |       0 | 1-9                    
-  branches.js                          |       0 |        0 |       0 |       0 | 1-20                   
-  branches.typescript.ts               |       0 |        0 |       0 |       0 | 1-25                   
- c8/test/fixtures/source-maps/classes  |       0 |        0 |       0 |       0 |                        
-  class-1.js                           |       0 |        0 |       0 |       0 | 1-5                    
-  class-2.js                           |       0 |        0 |       0 |       0 | 1-23                   
-  classes.js                           |       0 |        0 |       0 |       0 | 1-27                   
-  classes.typescript.ts                |       0 |        0 |       0 |       0 | 1-33                   
+All files                              |    3.21 |    12.24 |    6.38 |    3.21 |
+ c8                                    |       0 |        0 |       0 |       0 |
+  index.js                             |       0 |        0 |       0 |       0 | 1
+ c8/bin                                |       0 |        0 |       0 |       0 |
+  c8.js                                |       0 |        0 |       0 |       0 | 1-43
+ c8/coverage                           |       0 |        0 |       0 |       0 |
+  block-navigation.js                  |       0 |        0 |       0 |       0 | 1-87
+  prettify.js                          |       0 |        0 |       0 |       0 | 1-2
+  sorter.js                            |       0 |        0 |       0 |       0 | 1-196
+ c8/lib                                |       0 |        0 |       0 |       0 |
+  parse-args.js                        |       0 |        0 |       0 |       0 | 1-229
+  report.js                            |       0 |        0 |       0 |       0 | 1-542
+  source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100
+ c8/lib/commands                       |       0 |        0 |       0 |       0 |
+  check-coverage.js                    |       0 |        0 |       0 |       0 | 1-70
+  report.js                            |       0 |        0 |       0 |       0 | 1-44
+ c8/test/fixtures                      |   29.08 |    35.29 |      20 |   29.08 |
+  async.js                             |     100 |      100 |     100 |     100 |
+  c8-ignore-next.js                    |   54.54 |        0 |       0 |   54.54 | 1,3-4,9,12,17-19,21-22
+  c8-ignore-start-stop.js              |    61.9 |        0 |       0 |    61.9 | 1-4,10,16-18
+  computed-method.js                   |       0 |        0 |       0 |       0 | 1-15
+  custom-ext.special                   |      75 |    66.66 |   33.33 |      75 | 14-16,18-20
+  custom-ext2.special                  |       0 |        0 |       0 |       0 | 1-24
+  import-mcr.js                        |       0 |        0 |       0 |       0 | 1-12
+  issue-254.js                         |   28.57 |        0 |       0 |   28.57 | 1-2,5-7
+  multiple-spawn.js                    |       0 |        0 |       0 |       0 | 1-12
+  normal.js                            |       0 |        0 |       0 |       0 | 1-24
+  shebang.js                           |       0 |        0 |       0 |       0 | 1-8
+  subprocess.js                        |       0 |        0 |       0 |       0 | 1-15
+ c8/test/fixtures/all/ts-compiled      |       0 |        0 |       0 |       0 |
+  loaded.ts                            |       0 |        0 |       0 |       0 | 1-19
+  main.ts                              |       0 |        0 |       0 |       0 | 1-4
+ c8/test/fixtures/all/ts-compiled/dir  |       0 |        0 |       0 |       0 |
+  unloaded.ts                          |       0 |        0 |       0 |       0 | 1-5
+ c8/test/fixtures/all/vanilla          |       0 |        0 |       0 |       0 |
+  loaded.js                            |       0 |        0 |       0 |       0 | 1-19
+  main.js                              |       0 |        0 |       0 |       0 | 1-4
+ c8/test/fixtures/all/vanilla/dir      |       0 |        0 |       0 |       0 |
+  unloaded.js                          |       0 |        0 |       0 |       0 | 1-5
+ c8/test/fixtures/multidir1            |       0 |        0 |       0 |       0 |
+  file1.js                             |       0 |        0 |       0 |       0 | 1
+ c8/test/fixtures/multidir2            |       0 |        0 |       0 |       0 |
+  file2.js                             |       0 |        0 |       0 |       0 | 1
+ c8/test/fixtures/report               |       0 |        0 |       0 |       0 |
+  allowExternal.js                     |       0 |        0 |       0 |       0 | 1
+  report-multi-dir-external.js         |       0 |        0 |       0 |       0 | 1-12
+  report-single-dir-external.js        |       0 |        0 |       0 |       0 | 1-12
+  srcOverride.js                       |       0 |        0 |       0 |       0 | 1
+ c8/test/fixtures/source-maps          |       0 |        0 |       0 |       0 |
+  branches.js                          |       0 |        0 |       0 |       0 | 1-20
+  fake-source-map.js                   |       0 |        0 |       0 |       0 | 1-7
+ c8/test/fixtures/source-maps/branches |       0 |        0 |       0 |       0 |
+  branch-1.js                          |       0 |        0 |       0 |       0 | 1-12
+  branch-2.js                          |       0 |        0 |       0 |       0 | 1-9
+  branches.js                          |       0 |        0 |       0 |       0 | 1-20
+  branches.typescript.ts               |       0 |        0 |       0 |       0 | 1-25
+ c8/test/fixtures/source-maps/classes  |       0 |        0 |       0 |       0 |
+  class-1.js                           |       0 |        0 |       0 |       0 | 1-5
+  class-2.js                           |       0 |        0 |       0 |       0 | 1-23
+  classes.js                           |       0 |        0 |       0 |       0 | 1-27
+  classes.typescript.ts                |       0 |        0 |       0 |       0 | 1-33
 ---------------------------------------|---------|----------|---------|---------|------------------------
 ,"
 `;
@@ -405,14 +405,14 @@ exports[`c8 mergeAsync --all reports coverage for unloaded js files as 0 for lin
 positive
 negative
 --------------|---------|----------|---------|---------|-------------------
-File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 --------------|---------|----------|---------|---------|-------------------
-All files     |   64.28 |    66.66 |      50 |   64.28 |                   
- vanilla      |   78.26 |       75 |     100 |   78.26 |                   
-  loaded.js   |   73.68 |    71.42 |     100 |   73.68 | 4-5,16-18         
-  main.js     |     100 |      100 |     100 |     100 |                   
- vanilla/dir  |       0 |        0 |       0 |       0 |                   
-  unloaded.js |       0 |        0 |       0 |       0 | 1-5               
+All files     |   64.28 |    66.66 |      50 |   64.28 |
+ vanilla      |   78.26 |       75 |     100 |   78.26 |
+  loaded.js   |   73.68 |    71.42 |     100 |   73.68 | 4-5,16-18
+  main.js     |     100 |      100 |     100 |     100 |
+ vanilla/dir  |       0 |        0 |       0 |       0 |
+  unloaded.js |       0 |        0 |       0 |       0 | 1-5
 --------------|---------|----------|---------|---------|-------------------
 ,"
 `;
@@ -422,14 +422,14 @@ exports[`c8 mergeAsync --all reports coverage for unloaded transpiled ts files a
 positive
 negative
 -----------------|---------|----------|---------|---------|-------------------
-File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 -----------------|---------|----------|---------|---------|-------------------
-All files        |   64.28 |    57.14 |      50 |   64.28 |                   
- ts-compiled     |   78.26 |    66.66 |     100 |   78.26 |                   
-  loaded.ts      |   73.68 |    66.66 |     100 |   73.68 | 4-5,16-18         
-  main.ts        |     100 |      100 |     100 |     100 |                   
- ts-compiled/dir |       0 |        0 |       0 |       0 |                   
-  unloaded.ts    |       0 |        0 |       0 |       0 | 1-5               
+All files        |   64.28 |    57.14 |      50 |   64.28 |
+ ts-compiled     |   78.26 |    66.66 |     100 |   78.26 |
+  loaded.ts      |   73.68 |    66.66 |     100 |   73.68 | 4-5,16-18
+  main.ts        |     100 |      100 |     100 |     100 |
+ ts-compiled/dir |       0 |        0 |       0 |       0 |
+  unloaded.ts    |       0 |        0 |       0 |       0 | 1-5
 -----------------|---------|----------|---------|---------|-------------------
 ,"
 `;
@@ -439,14 +439,14 @@ exports[`c8 mergeAsync --all reports coverage for unloaded ts files as 0 for lin
 positive
 negative
 --------------|---------|----------|---------|---------|-------------------
-File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 --------------|---------|----------|---------|---------|-------------------
-All files     |   64.28 |    57.14 |      50 |   64.28 |                   
- ts-only      |   78.26 |    66.66 |     100 |   78.26 |                   
-  loaded.ts   |   73.68 |    66.66 |     100 |   73.68 | 4-5,16-18         
-  main.ts     |     100 |      100 |     100 |     100 |                   
- ts-only/dir  |       0 |        0 |       0 |       0 |                   
-  unloaded.ts |       0 |        0 |       0 |       0 | 1-5               
+All files     |   64.28 |    57.14 |      50 |   64.28 |
+ ts-only      |   78.26 |    66.66 |     100 |   78.26 |
+  loaded.ts   |   73.68 |    66.66 |     100 |   73.68 | 4-5,16-18
+  main.ts     |     100 |      100 |     100 |     100 |
+ ts-only/dir  |       0 |        0 |       0 |       0 |
+  unloaded.ts |       0 |        0 |       0 |       0 | 1-5
 --------------|---------|----------|---------|---------|-------------------
 ,"
 `;
@@ -456,14 +456,14 @@ exports[`c8 mergeAsync --all should allow for --all to be used in conjunction wi
 positive
 negative
 --------------|---------|----------|---------|---------|-------------------
-File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 --------------|---------|----------|---------|---------|-------------------
-All files     |   64.28 |    66.66 |      50 |   64.28 |                   
- vanilla      |   78.26 |       75 |     100 |   78.26 |                   
-  loaded.js   |   73.68 |    71.42 |     100 |   73.68 | 4-5,16-18         
-  main.js     |     100 |      100 |     100 |     100 |                   
- vanilla/dir  |       0 |        0 |       0 |       0 |                   
-  unloaded.js |       0 |        0 |       0 |       0 | 1-5               
+All files     |   64.28 |    66.66 |      50 |   64.28 |
+ vanilla      |   78.26 |       75 |     100 |   78.26 |
+  loaded.js   |   73.68 |    71.42 |     100 |   73.68 | 4-5,16-18
+  main.js     |     100 |      100 |     100 |     100 |
+ vanilla/dir  |       0 |        0 |       0 |       0 |
+  unloaded.js |       0 |        0 |       0 |       0 | 1-5
 --------------|---------|----------|---------|---------|-------------------
 ,ERROR: Coverage for lines (64.28%) does not meet global threshold (100%)
 ERROR: Coverage for branches (66.66%) does not meet global threshold (82%)
@@ -520,69 +520,69 @@ hey
 what
 hey
 ---------------------------------------|---------|----------|---------|---------|------------------------
-File                                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s      
+File                                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 ---------------------------------------|---------|----------|---------|---------|------------------------
-All files                              |    3.21 |    12.24 |    6.38 |    3.21 |                        
- c8                                    |       0 |        0 |       0 |       0 |                        
-  index.js                             |       0 |        0 |       0 |       0 | 1                      
- c8/bin                                |       0 |        0 |       0 |       0 |                        
-  c8.js                                |       0 |        0 |       0 |       0 | 1-43                   
- c8/coverage                           |       0 |        0 |       0 |       0 |                        
-  block-navigation.js                  |       0 |        0 |       0 |       0 | 1-87                   
-  prettify.js                          |       0 |        0 |       0 |       0 | 1-2                    
-  sorter.js                            |       0 |        0 |       0 |       0 | 1-196                  
- c8/lib                                |       0 |        0 |       0 |       0 |                        
-  parse-args.js                        |       0 |        0 |       0 |       0 | 1-229                  
-  report.js                            |       0 |        0 |       0 |       0 | 1-542                  
-  source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100                  
- c8/lib/commands                       |       0 |        0 |       0 |       0 |                        
-  check-coverage.js                    |       0 |        0 |       0 |       0 | 1-70                   
-  report.js                            |       0 |        0 |       0 |       0 | 1-44                   
- c8/test/fixtures                      |   29.08 |    35.29 |      20 |   29.08 |                        
-  async.js                             |     100 |      100 |     100 |     100 |                        
-  c8-ignore-next.js                    |   54.54 |        0 |       0 |   54.54 | 1,3-4,9,12,17-19,21-22 
-  c8-ignore-start-stop.js              |    61.9 |        0 |       0 |    61.9 | 1-4,10,16-18           
-  computed-method.js                   |       0 |        0 |       0 |       0 | 1-15                   
-  custom-ext.special                   |      75 |    66.66 |   33.33 |      75 | 14-16,18-20            
-  custom-ext2.special                  |       0 |        0 |       0 |       0 | 1-24                   
-  import-mcr.js                        |       0 |        0 |       0 |       0 | 1-12                   
-  issue-254.js                         |   28.57 |        0 |       0 |   28.57 | 1-2,5-7                
-  multiple-spawn.js                    |       0 |        0 |       0 |       0 | 1-12                   
-  normal.js                            |       0 |        0 |       0 |       0 | 1-24                   
-  shebang.js                           |       0 |        0 |       0 |       0 | 1-8                    
-  subprocess.js                        |       0 |        0 |       0 |       0 | 1-15                   
- c8/test/fixtures/all/ts-compiled      |       0 |        0 |       0 |       0 |                        
-  loaded.ts                            |       0 |        0 |       0 |       0 | 1-19                   
-  main.ts                              |       0 |        0 |       0 |       0 | 1-4                    
- c8/test/fixtures/all/ts-compiled/dir  |       0 |        0 |       0 |       0 |                        
-  unloaded.ts                          |       0 |        0 |       0 |       0 | 1-5                    
- c8/test/fixtures/all/vanilla          |       0 |        0 |       0 |       0 |                        
-  loaded.js                            |       0 |        0 |       0 |       0 | 1-19                   
-  main.js                              |       0 |        0 |       0 |       0 | 1-4                    
- c8/test/fixtures/all/vanilla/dir      |       0 |        0 |       0 |       0 |                        
-  unloaded.js                          |       0 |        0 |       0 |       0 | 1-5                    
- c8/test/fixtures/multidir1            |       0 |        0 |       0 |       0 |                        
-  file1.js                             |       0 |        0 |       0 |       0 | 1                      
- c8/test/fixtures/multidir2            |       0 |        0 |       0 |       0 |                        
-  file2.js                             |       0 |        0 |       0 |       0 | 1                      
- c8/test/fixtures/report               |       0 |        0 |       0 |       0 |                        
-  allowExternal.js                     |       0 |        0 |       0 |       0 | 1                      
-  report-multi-dir-external.js         |       0 |        0 |       0 |       0 | 1-12                   
-  report-single-dir-external.js        |       0 |        0 |       0 |       0 | 1-12                   
-  srcOverride.js                       |       0 |        0 |       0 |       0 | 1                      
- c8/test/fixtures/source-maps          |       0 |        0 |       0 |       0 |                        
-  branches.js                          |       0 |        0 |       0 |       0 | 1-20                   
-  fake-source-map.js                   |       0 |        0 |       0 |       0 | 1-7                    
- c8/test/fixtures/source-maps/branches |       0 |        0 |       0 |       0 |                        
-  branch-1.js                          |       0 |        0 |       0 |       0 | 1-12                   
-  branch-2.js                          |       0 |        0 |       0 |       0 | 1-9                    
-  branches.js                          |       0 |        0 |       0 |       0 | 1-20                   
-  branches.typescript.ts               |       0 |        0 |       0 |       0 | 1-25                   
- c8/test/fixtures/source-maps/classes  |       0 |        0 |       0 |       0 |                        
-  class-1.js                           |       0 |        0 |       0 |       0 | 1-5                    
-  class-2.js                           |       0 |        0 |       0 |       0 | 1-23                   
-  classes.js                           |       0 |        0 |       0 |       0 | 1-27                   
-  classes.typescript.ts                |       0 |        0 |       0 |       0 | 1-33                   
+All files                              |    3.21 |    12.24 |    6.38 |    3.21 |
+ c8                                    |       0 |        0 |       0 |       0 |
+  index.js                             |       0 |        0 |       0 |       0 | 1
+ c8/bin                                |       0 |        0 |       0 |       0 |
+  c8.js                                |       0 |        0 |       0 |       0 | 1-43
+ c8/coverage                           |       0 |        0 |       0 |       0 |
+  block-navigation.js                  |       0 |        0 |       0 |       0 | 1-87
+  prettify.js                          |       0 |        0 |       0 |       0 | 1-2
+  sorter.js                            |       0 |        0 |       0 |       0 | 1-196
+ c8/lib                                |       0 |        0 |       0 |       0 |
+  parse-args.js                        |       0 |        0 |       0 |       0 | 1-229
+  report.js                            |       0 |        0 |       0 |       0 | 1-542
+  source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100
+ c8/lib/commands                       |       0 |        0 |       0 |       0 |
+  check-coverage.js                    |       0 |        0 |       0 |       0 | 1-70
+  report.js                            |       0 |        0 |       0 |       0 | 1-44
+ c8/test/fixtures                      |   29.08 |    35.29 |      20 |   29.08 |
+  async.js                             |     100 |      100 |     100 |     100 |
+  c8-ignore-next.js                    |   54.54 |        0 |       0 |   54.54 | 1,3-4,9,12,17-19,21-22
+  c8-ignore-start-stop.js              |    61.9 |        0 |       0 |    61.9 | 1-4,10,16-18
+  computed-method.js                   |       0 |        0 |       0 |       0 | 1-15
+  custom-ext.special                   |      75 |    66.66 |   33.33 |      75 | 14-16,18-20
+  custom-ext2.special                  |       0 |        0 |       0 |       0 | 1-24
+  import-mcr.js                        |       0 |        0 |       0 |       0 | 1-12
+  issue-254.js                         |   28.57 |        0 |       0 |   28.57 | 1-2,5-7
+  multiple-spawn.js                    |       0 |        0 |       0 |       0 | 1-12
+  normal.js                            |       0 |        0 |       0 |       0 | 1-24
+  shebang.js                           |       0 |        0 |       0 |       0 | 1-8
+  subprocess.js                        |       0 |        0 |       0 |       0 | 1-15
+ c8/test/fixtures/all/ts-compiled      |       0 |        0 |       0 |       0 |
+  loaded.ts                            |       0 |        0 |       0 |       0 | 1-19
+  main.ts                              |       0 |        0 |       0 |       0 | 1-4
+ c8/test/fixtures/all/ts-compiled/dir  |       0 |        0 |       0 |       0 |
+  unloaded.ts                          |       0 |        0 |       0 |       0 | 1-5
+ c8/test/fixtures/all/vanilla          |       0 |        0 |       0 |       0 |
+  loaded.js                            |       0 |        0 |       0 |       0 | 1-19
+  main.js                              |       0 |        0 |       0 |       0 | 1-4
+ c8/test/fixtures/all/vanilla/dir      |       0 |        0 |       0 |       0 |
+  unloaded.js                          |       0 |        0 |       0 |       0 | 1-5
+ c8/test/fixtures/multidir1            |       0 |        0 |       0 |       0 |
+  file1.js                             |       0 |        0 |       0 |       0 | 1
+ c8/test/fixtures/multidir2            |       0 |        0 |       0 |       0 |
+  file2.js                             |       0 |        0 |       0 |       0 | 1
+ c8/test/fixtures/report               |       0 |        0 |       0 |       0 |
+  allowExternal.js                     |       0 |        0 |       0 |       0 | 1
+  report-multi-dir-external.js         |       0 |        0 |       0 |       0 | 1-12
+  report-single-dir-external.js        |       0 |        0 |       0 |       0 | 1-12
+  srcOverride.js                       |       0 |        0 |       0 |       0 | 1
+ c8/test/fixtures/source-maps          |       0 |        0 |       0 |       0 |
+  branches.js                          |       0 |        0 |       0 |       0 | 1-20
+  fake-source-map.js                   |       0 |        0 |       0 |       0 | 1-7
+ c8/test/fixtures/source-maps/branches |       0 |        0 |       0 |       0 |
+  branch-1.js                          |       0 |        0 |       0 |       0 | 1-12
+  branch-2.js                          |       0 |        0 |       0 |       0 | 1-9
+  branches.js                          |       0 |        0 |       0 |       0 | 1-20
+  branches.typescript.ts               |       0 |        0 |       0 |       0 | 1-25
+ c8/test/fixtures/source-maps/classes  |       0 |        0 |       0 |       0 |
+  class-1.js                           |       0 |        0 |       0 |       0 | 1-5
+  class-2.js                           |       0 |        0 |       0 |       0 | 1-23
+  classes.js                           |       0 |        0 |       0 |       0 | 1-27
+  classes.typescript.ts                |       0 |        0 |       0 |       0 | 1-33
 ---------------------------------------|---------|----------|---------|---------|------------------------
 ,"
 `;
@@ -953,21 +953,40 @@ All files          |     100 |      100 |     100 |     100 |
 ,"
 `;
 
-exports[`c8 mergeAsync should allow for multiple overrides of src location for --all 1`] = `
+exports[`c8 mergeAsync should allow for multiple include patterns 1`] = `
 ",hihi
 --------------------------------|---------|----------|---------|---------|-------------------
 File                            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
 --------------------------------|---------|----------|---------|---------|-------------------
-All files                       |    3.57 |    16.66 |       0 |    3.57 |                   
+All files                       |     3.7 |    16.66 |       0 |     3.7 |                   
  multidir1                      |       0 |        0 |       0 |       0 |                   
   file1.js                      |       0 |        0 |       0 |       0 | 1                 
  multidir2                      |       0 |        0 |       0 |       0 |                   
   file2.js                      |       0 |        0 |       0 |       0 | 1                 
- report                         |    3.84 |       25 |       0 |    3.84 |                   
+ report                         |       4 |       25 |       0 |       4 |                   
   allowExternal.js              |       0 |        0 |       0 |       0 | 1                 
-  report-multi-dir-external.js  |       0 |        0 |       0 |       0 | 1-12              
-  report-single-dir-external.js |       0 |        0 |       0 |       0 | 1-12              
+  report-multi-dir-external.js  |       0 |        0 |       0 |       0 | 1-13              
+  report-single-dir-external.js |       0 |        0 |       0 |       0 | 1-10              
   srcOverride.js                |     100 |      100 |     100 |     100 |                   
+--------------------------------|---------|----------|---------|---------|-------------------
+,"
+`;
+
+exports[`c8 mergeAsync should allow for multiple overrides of src location for --all 1`] = `
+",hihi
+--------------------------------|---------|----------|---------|---------|-------------------
+File                            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
+--------------------------------|---------|----------|---------|---------|-------------------
+All files                       |    3.57 |    16.66 |       0 |    3.57 |
+ multidir1                      |       0 |        0 |       0 |       0 |
+  file1.js                      |       0 |        0 |       0 |       0 | 1
+ multidir2                      |       0 |        0 |       0 |       0 |
+  file2.js                      |       0 |        0 |       0 |       0 | 1
+ report                         |    3.84 |       25 |       0 |    3.84 |
+  allowExternal.js              |       0 |        0 |       0 |       0 | 1
+  report-multi-dir-external.js  |       0 |        0 |       0 |       0 | 1-12
+  report-single-dir-external.js |       0 |        0 |       0 |       0 | 1-12
+  srcOverride.js                |     100 |      100 |     100 |     100 |
 --------------------------------|---------|----------|---------|---------|-------------------
 ,"
 `;
@@ -1351,21 +1370,40 @@ All files          |     100 |      100 |     100 |     100 |
 ,"
 `;
 
-exports[`c8 should allow for multiple overrides of src location for --all 1`] = `
+exports[`c8 should allow for multiple include patterns 1`] = `
 ",hihi
 --------------------------------|---------|----------|---------|---------|-------------------
 File                            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
 --------------------------------|---------|----------|---------|---------|-------------------
-All files                       |    3.57 |    16.66 |       0 |    3.57 |                   
+All files                       |     3.7 |    16.66 |       0 |     3.7 |                   
  multidir1                      |       0 |        0 |       0 |       0 |                   
   file1.js                      |       0 |        0 |       0 |       0 | 1                 
  multidir2                      |       0 |        0 |       0 |       0 |                   
   file2.js                      |       0 |        0 |       0 |       0 | 1                 
- report                         |    3.84 |       25 |       0 |    3.84 |                   
+ report                         |       4 |       25 |       0 |       4 |                   
   allowExternal.js              |       0 |        0 |       0 |       0 | 1                 
-  report-multi-dir-external.js  |       0 |        0 |       0 |       0 | 1-12              
-  report-single-dir-external.js |       0 |        0 |       0 |       0 | 1-12              
+  report-multi-dir-external.js  |       0 |        0 |       0 |       0 | 1-13              
+  report-single-dir-external.js |       0 |        0 |       0 |       0 | 1-10              
   srcOverride.js                |     100 |      100 |     100 |     100 |                   
+--------------------------------|---------|----------|---------|---------|-------------------
+,"
+`;
+
+exports[`c8 should allow for multiple overrides of src location for --all 1`] = `
+",hihi
+--------------------------------|---------|----------|---------|---------|-------------------
+File                            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
+--------------------------------|---------|----------|---------|---------|-------------------
+All files                       |    3.57 |    16.66 |       0 |    3.57 |
+ multidir1                      |       0 |        0 |       0 |       0 |
+  file1.js                      |       0 |        0 |       0 |       0 | 1
+ multidir2                      |       0 |        0 |       0 |       0 |
+  file2.js                      |       0 |        0 |       0 |       0 | 1
+ report                         |    3.84 |       25 |       0 |    3.84 |
+  allowExternal.js              |       0 |        0 |       0 |       0 | 1
+  report-multi-dir-external.js  |       0 |        0 |       0 |       0 | 1-12
+  report-single-dir-external.js |       0 |        0 |       0 |       0 | 1-12
+  srcOverride.js                |     100 |      100 |     100 |     100 |
 --------------------------------|---------|----------|---------|---------|-------------------
 ,"
 `;


### PR DESCRIPTION
This PR fixes the issue #498...and also change the philosophy of c8.

### The fix

This PR makes c8 consider the `include` and `exclude` patterns as relative to the configuration file location, if any, or the current working directory, otherwise. By applying such a change, c8 can be executed from any subdirectory of the project and will always resolve sources to include and exclude regardless of the current working directory, if a configuration file is present.

### The philosophy shift

c8 philosophy seems to have been heavily inspired by nyc, which means that it inherits from nyc debatable (and arguably archaic) design decisions. These decisions can be summarized this way:

Options `src`, `include`, `exclude`, `extension`, `excludeNodeModules`, `allowExternal` and `all` are overlapping and can be reduced to only `include` and `exclude` without removing any feature.

This PR removes all the mentioned options except `include` and `exclude`, and updates the logic so that all the removed options are organically available through the `include` and `exclude` options.

Let's see how it goes.

#### --src

This option is overlapping with the `include` option, which _is_ the declaration of the files that we want to be covered by the tests:

```
--include=src/main/**/*.js
```

#### --extension

This option is overlapping with the `include` option, which _is_ the declaration of the files that we want to be covered by the tests:

```
--include=src/main/**/*.ts --include=src/main/**/*.tsx
```

Or:

```
--include=src/main/**/*.{ts,tsx}
```

#### --allowExternal

This option is overlapping with the `include` option, which _is_ the declaration of the files that we want to be covered by the tests:

```
--include=src/main/**/*.ts --include=../../../../external-project/*.js
```

#### --excludeNodeModules

This option is overlapping with the `exclude` option, which _is_ the declaration of the files that we don't want to be covered by the tests:

```
--include=**/*.js --exclude=node_modules/**/*
```

#### --all

This option is overlapping with the `include` and `exclude` options, would we want to not include all of them, it is possible through a combination of `include` and `exclude`:

```
--include=**/*.js --exclude=**/not-included/*.js
```

This is obviously a breaking change.
