### PR TITLE
chore: .editorconfig to avoid unintended mods to .snap files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,8 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.snap]
+trim_trailing_whitespace = false
+
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
when creating my last PR, my editor stripped all trailing whitespace on all lines from the updated snapshot file. Changing `.editorconfig` fixed that

##### Checklist
- [x] `npm test`, tests passing

