### PR TITLE
fix: print c8's own version with yargs 18

### DIFF
--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -6,10 +6,12 @@ const Yargs = require('yargs/yargs')
 const { applyExtends } = require('yargs/helpers')
 const parser = require('yargs-parser')
 const { resolve } = require('path')
+const { version } = require('../package.json')
 
 function buildYargs (withCommands = false) {
   const yargs = Yargs([])
     .usage('$0 [opts] [script] [opts]')
+    .version(version)
     .options('config', {
       alias: 'c',
       config: true,

--- a/test/integration.js.snap
+++ b/test/integration.js.snap
@@ -166,7 +166,7 @@ All files                              |    3.18 |    12.24 |    6.38 |    3.18 
   prettify.js                          |       0 |        0 |       0 |       0 | 1-2                    
   sorter.js                            |       0 |        0 |       0 |       0 | 1-210                  
  c8/lib                                |       0 |        0 |       0 |       0 |                        
-  parse-args.js                        |       0 |        0 |       0 |       0 | 1-229                  
+  parse-args.js                        |       0 |        0 |       0 |       0 | 1-231                  
   report.js                            |       0 |        0 |       0 |       0 | 1-542                  
   source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100                  
  c8/lib/commands                       |       0 |        0 |       0 |       0 |                        
@@ -532,7 +532,7 @@ All files                              |    3.18 |    12.24 |    6.38 |    3.18 
   prettify.js                          |       0 |        0 |       0 |       0 | 1-2                    
   sorter.js                            |       0 |        0 |       0 |       0 | 1-210                  
  c8/lib                                |       0 |        0 |       0 |       0 |                        
-  parse-args.js                        |       0 |        0 |       0 |       0 | 1-229                  
+  parse-args.js                        |       0 |        0 |       0 |       0 | 1-231                  
   report.js                            |       0 |        0 |       0 |       0 | 1-542                  
   source-map-from-file.js              |       0 |        0 |       0 |       0 | 1-100                  
  c8/lib/commands                       |       0 |        0 |       0 |       0 |                        

--- a/test/parse-args.js
+++ b/test/parse-args.js
@@ -6,7 +6,11 @@ const {
   hideInstrumenterArgs
 } = require('../lib/parse-args')
 
+const { spawnSync } = require('child_process')
+const { mkdtempSync, writeFileSync } = require('fs')
+const { tmpdir } = require('os')
 const { join, resolve } = require('path')
+const { version } = require('../package.json')
 
 describe('parse-args', () => {
   describe('hideInstrumenteeArgs', () => {
@@ -84,6 +88,27 @@ describe('parse-args', () => {
       const argsArray = ['node', 'c8', '--lines', '100', '--temp-directory', tmpDir]
       const argv = buildYargs().parse(argsArray)
       argv.tempDirectory.should.be.equal(tmpDir)
+    })
+  })
+
+  describe('--version', () => {
+    it('prints the c8 package version from a cwd whose package.json differs', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'c8-version-'))
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({
+        name: 'app',
+        version: '1.0.0'
+      }))
+      const env = { ...process.env }
+      delete env.NODE_V8_COVERAGE
+      const result = spawnSync(process.execPath, [require.resolve('../bin/c8'), '--version'], {
+        cwd: dir,
+        encoding: 'utf8',
+        env
+      })
+      result.status.should.equal(0)
+      result.stdout.trim().should.equal(version)
+      result.stdout.trim().should.not.equal('1.0.0')
+      result.stdout.trim().should.not.equal('unknown')
     })
   })
 


### PR DESCRIPTION
After the yargs 18 bump in v12, `c8 --version` no longer reads this package's version. It prints `unknown`, or in some installs the consuming app's version, which is what #607 ran into.

This sets `.version()` from c8's own package.json so the CLI always reports the published version. The test runs the bin from a cwd whose package.json is `1.0.0` so we don't pick that up again.

Fixes #607

##### Checklist
- [x] `npm test`, tests passing
- [x] `npm run test:snap` (to update the snapshot)
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added